### PR TITLE
add support for new GROQ models and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,16 @@ _aicommit2_ is a reactive CLI tool that automatically generates Git commit messa
 
 1. Install _aicommit2_:
 
+**Directly from npm**:
 ```sh
 npm install -g aicommit2
+```
+**Alternatively, from source**:
+```sh
+git clone https://github.com/tak-bro/aicommit2.git
+cd aicommit2
+npm run build
+npm install -g .
 ```
 
 2. Set up API keys (**at least ONE key must be set**):
@@ -547,7 +555,7 @@ Anthropic does not support the following options in General Settings.
 | Setting            | Description            | Default                |
 |--------------------|------------------------|------------------------|
 | `key`              | API key                | -                      |
-| `model`            | Model to use           | `gemini-2.0-flash-exp` |
+| `model`            | Model to use           | `gemini-2.0-flash`     |
 
 ##### GEMINI.key
 
@@ -670,10 +678,10 @@ Cohere does not support the following options in General Settings.
 
 ### Groq
 
-| Setting            | Description            | Default        |
-|--------------------|------------------------|----------------|
-| `key`              | API key                | -              |
-| `model`            | Model to use           | `gemma2-9b-it` |
+| Setting            | Description            | Default                         |
+|--------------------|------------------------|---------------------------------|
+| `key`              | API key                | -                               |
+| `model`            | Model to use           | `deepseek-r1-distill-llama-70b` |
 
 ##### GROQ.key
 
@@ -681,9 +689,13 @@ The Groq API key. If you don't have one, please sign up and get the API key in [
 
 ##### GROQ.model
 
-Default: `gemma2-9b-it`
+Default: `deepseek-r1-distill-llama-70b`
 
 Supported:
+- `qwen-2.5-32b`
+- `qwen-2.5-coder-32b`
+- `deepseek-r1-distill-qwen-32b`
+- `deepseek-r1-distill-llama-70b`
 - `distil-whisper-large-v3-en`
 - `gemma2-9b-it`
 - `llama-3.3-70b-versatile`
@@ -702,7 +714,7 @@ Supported:
 
 
 ```sh
-aicommit2 config set GROQ.model="llama-3.3-70b-versatile"
+aicommit2 config set GROQ.model="deepseek-r1-distill-llama-70b"
 ```
 
 ### Perplexity

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -303,7 +303,7 @@ const modelConfigParsers: Record<ModelName, Record<string, (value: any) => any>>
         key: (key?: string) => key || '',
         model: (model?: string) => {
             if (!model || model.length === 0) {
-                return 'gemini-2.0-flash-exp';
+                return 'gemini-2.0-flash';
             }
             const supportModels = [
                 `gemini-2.0-flash`,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -536,7 +536,6 @@ const modelConfigParsers: Record<ModelName, Record<string, (value: any) => any>>
                 `qwen-2.5-coder-32b`,
                 `deepseek-r1-distill-qwen-32b`,
                 `deepseek-r1-distill-llama-70b`,
-                `distil-whisper-large-v3-en`,
                 `gemma2-9b-it`,
                 `llama-3.3-70b-versatile`,
                 `llama-3.1-8b-instant`,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -529,9 +529,13 @@ const modelConfigParsers: Record<ModelName, Record<string, (value: any) => any>>
         key: (key?: string) => key || '',
         model: (model?: string) => {
             if (!model || model.length === 0) {
-                return 'gemma2-9b-it';
+                return 'deepseek-r1-distill-llama-70b';
             }
             const supportModels = [
+                `qwen-2.5-32b`,
+                `qwen-2.5-coder-32b`,
+                `deepseek-r1-distill-qwen-32b`,
+                `deepseek-r1-distill-llama-70b`,
                 `distil-whisper-large-v3-en`,
                 `gemma2-9b-it`,
                 `llama-3.3-70b-versatile`,
@@ -540,6 +544,7 @@ const modelConfigParsers: Record<ModelName, Record<string, (value: any) => any>>
                 `llama3-70b-8192`,
                 `llama3-8b-8192`,
                 `mixtral-8x7b-32768`,
+                `distil-whisper-large-v3-en`,
                 `whisper-large-v3`,
                 `whisper-large-v3-turbo`,
                 `llama-3.3-70b-specdec`,


### PR DESCRIPTION
### Description
This PR introduces support for additional GROQ models and updates the documentation accordingly:

- **Feature:** Added support for new GROQ models:
  - `qwen-2.5-32b`
  - `qwen-2.5-coder-32b`
  - `deepseek-r1-distill-qwen-32b`
  - `deepseek-r1-distill-llama-70b`

- **Documentation:** Updated the README to reflect the changes:
  - Added installation instructions from source.
  - Changed the default GROQ model from `gemma2-9b-it` to `deepseek-r1-distill-llama-70b`
  - Updated the list of supported models
  - Adjusted the example configuration command

### Testing
- Verified the changes in the README reflect the correct supported models.
- Confirmed that new models are correctly recognized in the system.

### Additional context
This update ensures better compatibility with the latest GROQ models and improves clarity in the documentation.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
