### PR TITLE
docs: add pre-commit configuration for aicommit2

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,30 @@ Make sure you have:
 > **Note** : The `--pre-commit` flag is specifically designed for use with the pre-commit framework and ensures proper integration with other pre-commit hooks.
 
 
+The configuration below will run aicommit2 only when available on the system and includes workaround for passing on the commit message:
+
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: aicommit2
+        name: AI Commit Message Generator
+        entry: |
+          python -c "
+          import shutil, sys, subprocess
+          if shutil.which('aicommit2'):
+              msg_path = sys.argv[1] if len(sys.argv) > 1 else '.git/COMMIT_EDITMSG'
+              subprocess.run(['aicommit2', '--pre-commit', msg_path] + sys.argv[2:], check=True)
+          else:
+              print('aicommit2 is not available. Skipping AI Commit Message Generator.')
+          "
+        language: python
+        stages: [prepare-commit-msg]
+        always_run: true
+```
+
+
 #### Uninstall
 
 In the Git repository you want to uninstall the hook from:


### PR DESCRIPTION
### Description

Implements:
- Conditional execution of aicommit2: only when locally instaled;
- Ensure argument is passed to aicommit2.

In my setup the argument (commit message file) was not provided to aicommit2.
This is basically because of the pre-commit hook script itself (the script generated under .git/hooks).
So in case there is no argument provided to the hook execution, it is filled in with the standard path.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
