### PR TITLE
 feat(ollama): add support for maxTokens option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,20 @@
 ## [2.2.17](https://github.com/tak-bro/aicommit2/compare/v2.2.16...v2.2.17) (2025-05-26)
 
-
 ### Bug Fixes
 
-* **openai-compatible:** prevent 'undefined' choices error in message generation ([e47d670](https://github.com/tak-bro/aicommit2/commit/e47d6705e68656dd0eb31e69f367ecc0781fd398))
-
+- **openai-compatible:** prevent 'undefined' choices error in message generation ([e47d670](https://github.com/tak-bro/aicommit2/commit/e47d6705e68656dd0eb31e69f367ecc0781fd398))
 
 ### Features
 
-* **ai:** support multiple models per service ([5500614](https://github.com/tak-bro/aicommit2/commit/55006141141a68a0a81a46c263aab295e06af07f))
-* **config:** add config path and XDG support ([7221e28](https://github.com/tak-bro/aicommit2/commit/7221e2849095d551746bb5a1b1708f229bffad54))
-* **config:** add envKey configuration for custom API key environment variables ([eac2c57](https://github.com/tak-bro/aicommit2/commit/eac2c57f40258541d29b57fcb91ce079033f1cae))
-* **config:** allow relative paths for prompt files ([7ef098b](https://github.com/tak-bro/aicommit2/commit/7ef098bdfd3ebb4a85b457ff2a84296ca9cd3632))
-* **gemini:** add gemini-2.5-flash-preview-05-20 model ([31d1939](https://github.com/tak-bro/aicommit2/commit/31d1939f4e7459585c88936280d53fd6c94760a4))
-* implement XDG config path lookup ([c6f0126](https://github.com/tak-bro/aicommit2/commit/c6f01260658043e844d46f21d5588791d1771589))
-* **logger:** add option to disable file logging ([ca0af40](https://github.com/tak-bro/aicommit2/commit/ca0af4010bc3ac5c730a72efee374dc1e0d9e8d1))
-* **logging:** implement file logging with daily rotation ([d4f4c34](https://github.com/tak-bro/aicommit2/commit/d4f4c34fa0bf80307afb0616f42ebe3ac3e9368c))
-* **output:** add diff character count to staged message ([4e8d50e](https://github.com/tak-bro/aicommit2/commit/4e8d50e93f28a3eb270fb639431d701add3ca182))
+- **ai:** support multiple models per service ([5500614](https://github.com/tak-bro/aicommit2/commit/55006141141a68a0a81a46c263aab295e06af07f))
+- **config:** add config path and XDG support ([7221e28](https://github.com/tak-bro/aicommit2/commit/7221e2849095d551746bb5a1b1708f229bffad54))
+- **config:** add envKey configuration for custom API key environment variables ([eac2c57](https://github.com/tak-bro/aicommit2/commit/eac2c57f40258541d29b57fcb91ce079033f1cae))
+- **config:** allow relative paths for prompt files ([7ef098b](https://github.com/tak-bro/aicommit2/commit/7ef098bdfd3ebb4a85b457ff2a84296ca9cd3632))
+- **gemini:** add gemini-2.5-flash-preview-05-20 model ([31d1939](https://github.com/tak-bro/aicommit2/commit/31d1939f4e7459585c88936280d53fd6c94760a4))
+- implement XDG config path lookup ([c6f0126](https://github.com/tak-bro/aicommit2/commit/c6f01260658043e844d46f21d5588791d1771589))
+- **logger:** add option to disable file logging ([ca0af40](https://github.com/tak-bro/aicommit2/commit/ca0af4010bc3ac5c730a72efee374dc1e0d9e8d1))
+- **logging:** implement file logging with daily rotation ([d4f4c34](https://github.com/tak-bro/aicommit2/commit/d4f4c34fa0bf80307afb0616f42ebe3ac3e9368c))
+- **output:** add diff character count to staged message ([4e8d50e](https://github.com/tak-bro/aicommit2/commit/4e8d50e93f28a3eb270fb639431d701add3ca182))
 
 ## [2.2.16](https://github.com/tak-bro/aicommit2/compare/v2.2.15...v2.2.16) (2025-05-19)
 

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -52,21 +52,22 @@ aicommit2 config set OLLAMA.model="llama3.2"
 aicommit2 config set OLLAMA.model="codellama" \
     OLLAMA.numCtx=4096 \
     OLLAMA.temperature=0.7 \
-    OLLAMA.maxTokens=4000 \
     OLLAMA.locale="en" \
     OLLAMA.generate=3 \
-    OLLAMA.topP=0.9
+    OLLAMA.topP=0.9 \
+    OLLAMA.maxTokens=4000
 ```
 
 ## Settings
 
-| Setting  | Description                                                | Default                |
-| -------- | ---------------------------------------------------------- | ---------------------- |
-| `model`  | Model(s) to use (comma-separated list)                     | -                      |
-| `host`   | Ollama host URL                                            | http://localhost:11434 |
-| `auth`   | Authentication type                                        | Bearer                 |
-| `key`    | Authentication key                                         | -                      |
-| `numCtx` | The maximum number of tokens the model can process at once | 2048                   |
+| Setting     | Description                                                 | Default                  |
+| ----------- | ----------------------------------------------------------- | ------------------------ |
+| `model`     | Model(s) to use (comma-separated list)                      | -                        |
+| `host`      | Ollama host URL                                             | http://localhost:11434   |
+| `auth`      | Authentication type                                         | Bearer                   |
+| `key`       | Authentication key                                          | -                        |
+| `numCtx`    | The maximum number of tokens the model can process at once  | 2048                     |
+| `maxTokens` | The maximum number of output tokens (maps to `num_predict`) | -1 (infinite generation) |
 
 ## Configuration
 
@@ -128,11 +129,15 @@ It is recommended to set it to 4096 or higher.
 aicommit2 config set OLLAMA.numCtx=4096
 ```
 
-#### Unsupported Options
+#### OLLAMA.maxTokens
 
-Ollama does not support the following options in General Settings.
+Default: `-1` (infinite generation)
 
-- maxTokens
+The maximum number of output tokens to generate. This maps to Ollama's `num_predict` option.
+
+```sh
+aicommit2 config set OLLAMA.maxTokens=4000
+```
 
 ## Loading Multiple Ollama Models
 

--- a/src/services/ai/ollama.service.ts
+++ b/src/services/ai/ollama.service.ts
@@ -114,7 +114,8 @@ export class OllamaService extends AIService {
     }
 
     private async createChatCompletions(systemPrompt: string, userMessage: string) {
-        const isStream = this.params.config.stream || false;
+        const { stream, numCtx, temperature, topP, timeout, maxTokens } = this.params.config;
+        const isStream = stream || false;
 
         const response = await this.ollama.chat({
             model: this.model,
@@ -129,12 +130,13 @@ export class OllamaService extends AIService {
                 },
             ],
             stream: isStream,
-            keep_alive: this.params.config.timeout,
+            keep_alive: timeout,
             options: {
-                num_ctx: this.params.config.numCtx,
-                temperature: this.params.config.temperature,
-                top_p: this.params.config.topP,
+                num_ctx: numCtx,
+                temperature: temperature,
+                top_p: topP,
                 seed: getRandomNumber(10, 1000),
+                num_predict: maxTokens ?? -1,
             },
         });
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -613,6 +613,7 @@ const modelConfigParsers: Record<ModelName, Record<string, (value: any) => any>>
         systemPromptPath: generalConfigParsers.systemPromptPath,
         codeReviewPromptPath: generalConfigParsers.codeReviewPromptPath,
         temperature: generalConfigParsers.temperature,
+        maxTokens: generalConfigParsers.maxTokens,
         logging: generalConfigParsers.logging,
         locale: generalConfigParsers.locale,
         generate: generalConfigParsers.generate,


### PR DESCRIPTION
- Add `maxTokens` configuration option for the Ollama provider.
- Map `maxTokens` to the `num_predict` parameter in the Ollama API call.
- Update documentation to include the new option and its default value (-1 for infinite generation).
______________________________________________________________________

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
