### PR TITLE
feat(gemini): add support for new Gemini 2.5 models

### DIFF
--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -51,8 +51,11 @@ Default: `gemini-2.0-flash`
 
 Supported:
 
+- `gemini-2.5-flash`
 - `gemini-2.5-flash-preview-04-17`
 - `gemini-2.5-flash-preview-05-20`
+- `gemini-2.5-flash-lite-preview-06-17`
+- `gemini-2.5-pro`
 - `gemini-2.5-pro-preview-05-06`
 - `gemini-2.0-flash`
 - `gemini-2.0-flash-lite`

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -423,8 +423,11 @@ const modelConfigParsers: Record<ModelName, Record<string, (value: any) => any>>
             }
             const modelList = typeof model === 'string' ? model?.split(',') : model;
             const supportModels = [
+                `gemini-2.5-flash`,
                 `gemini-2.5-flash-preview-04-17`,
                 `gemini-2.5-flash-preview-05-20`,
+                `gemini-2.5-flash-lite-preview-06-17`,
+                `gemini-2.5-pro`,
                 `gemini-2.5-pro-preview-05-06`,
                 `gemini-2.0-flash`,
                 `gemini-2.0-flash-lite`,
@@ -1006,9 +1009,9 @@ export const addConfigs = async (keyValues: [key: string, value: any][]) => {
             const valueToAdd =
                 typeof value === 'string'
                     ? value
-                          .split(',')
-                          .map(v => v.trim())
-                          .filter(v => !!v)
+                        .split(',')
+                        .map(v => v.trim())
+                        .filter(v => !!v)
                     : value;
             (config[modelName] as Record<string, any>)[modelKey] = flattenDeep([...originModels, ...valueToAdd]);
             continue;


### PR DESCRIPTION
Integrate `gemini-2.5-flash`, `gemini-2.5-flash-lite-preview-06-17`, and `gemini-2.5-pro` into the list of recognized and supported models. 

Please don't use the old Genini naming until Google supports maintaining backward compatibility.

This enables the system to correctly identify and utilize these newer Gemini models for various operations.
