### PR TITLE
fix(logger): suppress winston message about missing transports

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -57,6 +57,8 @@ export async function initializeLogger(options?: {
                 ),
             })
         );
+    } else {
+        transports.push(new winston.transports.Console());
     }
 
     loggerInstance = winston.createLogger({
@@ -76,6 +78,7 @@ export async function initializeLogger(options?: {
               ]
             : [],
         exitOnError: false, // Do not exit on handled exceptions
+        silent: !logging,
     });
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -58,7 +58,7 @@ export async function initializeLogger(options?: {
             })
         );
     } else {
-        transports.push(new winston.transports.Console());
+        transports.push(new winston.transports.Console({ silent: true }));
     }
 
     loggerInstance = winston.createLogger({


### PR DESCRIPTION
- Added a console transport to the logger initialization
- Updated logger configuration to include silent option based on logging parameter
 
### Issue

#158

### Description

When logging is disabled, this PR adds a default console transport and configures a silent logger 

### Testing

Manual tests:

- When logging is disabled, wiston message about transports is no longer printed
- When logging is enabled, `aicommit2` writes to the usual log files
______________________________________________________________________

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

✅