### PR TITLE
chore(nix): bump to version 2.4.8 & fix pnpm errors

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,13 +17,13 @@
       perSystem = {pkgs, ...}: {
         packages.default = pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
           pname = "aicommit2";
-          version = "v2.3.3";
+          version = "v2.4.8";
           src = self;
 
           pnpmDeps = pkgs.pnpm.fetchDeps {
             inherit (finalAttrs) pname version src;
             fetcherVersion = 1;
-            hash = "sha256-gRsu4J5XRKkzV5/Sl9Ud/HjO8hFEddo/MnSv+UCNSXg=";
+            hash = "sha256-nUa7GH8oI5/nsigWiHj1O46/3nD+H1GZ1OsMoHhmqMo=";
           };
 
           nativeBuildInputs = [


### PR DESCRIPTION
### Description
-> update package to version 2.4.8
-> fix ERR_PNPM_NO_OFFLINE_TARBALL build error

### Testing
Tested to build successfully on x86_64-darwin system.

______________________________________________________________________

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.