### PR TITLE
chore(nix): update flake.nix to version v2.4.11

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,13 +17,13 @@
       perSystem = {pkgs, ...}: {
         packages.default = pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
           pname = "aicommit2";
-          version = "v2.4.8";
+          version = "v2.4.11";
           src = self;
 
           pnpmDeps = pkgs.pnpm.fetchDeps {
             inherit (finalAttrs) pname version src;
             fetcherVersion = 1;
-            hash = "sha256-nUa7GH8oI5/nsigWiHj1O46/3nD+H1GZ1OsMoHhmqMo=";
+            hash = "sha256-BkJZldFkAGqDsTQ2a/NM4W1vVGNzc1HysqeYFG25Hd4=";
           };
 
           nativeBuildInputs = [


### PR DESCRIPTION
This PR updates flake.nix with:
- New version: v2.4.11
- New hash: sha256-BkJZldFkAGqDsTQ2a/NM4W1vVGNzc1HysqeYFG25Hd4=

This update was performed automatically by a GitHub workflow.