### PR TITLE
docs: update prepare-commit-msg setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,11 +275,11 @@ aicommit2 --all # or -a
 - `--disable-lowercase`: Disable automatic lowercase conversion of commit messages (default: **false**)
   - Preserves the original casing of commit types and descriptions
   - Useful when working with custom commit conventions that require specific casing
-- `--hook-mode`: Run as a Git hook, typically used with prepare-commit-msg hook (default: **false**)
+- `--hook-mode`: Run as a Git hook, typically used with [`prepare-commit-msg` hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks#_committing_workflow_hooks) hook (default: **false**)
   - This mode is automatically enabled when running through the Git hook system
   - See [Git hook](#git-hook) section for more details
 - `--pre-commit`: Run in [pre-commit](https://pre-commit.com/) framework mode (default: **false**)
-  - This option is specifically for use with the pre-commit framework or manually in a [`prepare-commit-msg` hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks#_committing_workflow_hooks)
+  - This option is specifically for use with the pre-commit framework
   - See [Integration with pre-commit framework](#integration-with-pre-commit-framework) section for setup instructions
 
 Examples:
@@ -320,6 +320,10 @@ Make the hook executable:
 chmod +x .git/hooks/prepare-commit-msg
 ```
 
+##### Use with a custom `core.hooksPath`
+
+If you are using [`husky`](https://typicode.github.io/husky/)** or have configured a custom [`core.hooksPath`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-corehooksPath), update the corresponding hooks file instead. For Husky users, this file is `.husky/prepare-commit-message`.
+
 #### Integration with pre-commit Framework
 
 If you're using the [pre-commit](https://pre-commit.com/) framework, you can add _aicommit2_ to your `.pre-commit-config.yaml`:
@@ -353,12 +357,6 @@ aicommit2 hook uninstall
 ```
 
 Or manually delete the `.git/hooks/prepare-commit-msg` file.
-
-#### Manual setup without the pre-commit Framework
-
-Add the line `aicommit2 --pre-commit "$@"` to the `.git/hooks/prepare-commit-msg` file in your Git repository.
-
-If you are using [`husky`](https://typicode.github.io/husky/)** or have configured a custom [`core.hooksPath`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-corehooksPath), update the corresponding hooks file instead. For Husky users, this file is `.husky/prepare-commit-message`.
 
 ### Configuration
 


### PR DESCRIPTION
### Issue

~~Issue number, if available, prefixed with "#"~~ N/A

### Description

Documentation. I use `husky`, ~~and the instructions make it sound like it can only be used with the `pre-commit` framework, rather than any git prepare commit message hook.~~ I missed the initial mention of prepare-commit-msg. I've updated the PR to clean that up and add a mention of hooksPath and husky.

### Testing

~~It's documentation. I used the `--pre-commit` option without the pre-commit framework~~ _I've updated my use to use the `--hook-mode`, and it worked fine (though I dislike the excessive advice preceding the generated message, and i remove that with `sed` after running `aicommit2`, but i digress)

### Additional context

I haven't used `jj` enough to know if they use a separate hook setup. (I dabbled, but it was a little overbearing for my already-established git workflow).

Also, after doing a bit of code review on the difference between the `hook-mode` and `pre-commit` implementation, there's a lot of duplicate code there, but that's typical of vibe coding. (i only want this tool to break through writer's block in commit messages, i dont really suffer from coder's block)

______________________________________________________________________

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
