### PR TITLE
feat(cli): add verbose logging option for enhanced debugging

### DIFF
--- a/src/commands/aicommit2.ts
+++ b/src/commands/aicommit2.ts
@@ -36,6 +36,7 @@ export default async (
     autoSelect: boolean,
     edit: boolean,
     disableLowerCase: boolean,
+    verbose: boolean,
     rawArgv: string[]
 ) =>
     (async () => {
@@ -50,17 +51,20 @@ export default async (
             // For Jujutsu, no staging needed - working copy is already staged
         }
 
-        const config = await getConfig(
-            {
-                locale: locale?.toString() as string,
-                generate: generate?.toString() as string,
-                type: commitType?.toString() as string,
-                systemPrompt: prompt?.toString() as string,
-                includeBody: includeBody?.toString() as string,
-                disableLowerCase: disableLowerCase?.toString() as string,
-            },
-            rawArgv
-        );
+        const configOverrides: RawConfig = {
+            locale: locale?.toString() as string,
+            generate: generate?.toString() as string,
+            type: commitType?.toString() as string,
+            systemPrompt: prompt?.toString() as string,
+            includeBody: includeBody?.toString() as string,
+            disableLowerCase: disableLowerCase?.toString() as string,
+        };
+
+        if (verbose) {
+            configOverrides.logLevel = 'verbose';
+        }
+
+        const config = await getConfig(configOverrides, rawArgv);
 
         const shouldIncludeBody = includeBody === true || config.includeBody === true;
         if (shouldIncludeBody) {

--- a/src/commands/pre-commit-hook.ts
+++ b/src/commands/pre-commit-hook.ts
@@ -12,7 +12,7 @@ import { getStagedDiff } from '../utils/vcs.js';
 const args = process.argv.slice(2).filter(arg => !arg.startsWith('--pre-commit'));
 const [messageFilePath, commitSource] = args;
 
-export default () =>
+export default (verbose = false) =>
     (async () => {
         if (!messageFilePath) {
             throw new KnownError('Commit message file path is missing. This file should be called from the "pre-commit framework"');
@@ -33,7 +33,12 @@ export default () =>
         const consoleManager = new ConsoleManager();
         consoleManager.printTitle();
 
-        const config = await getConfig({});
+        const cliOverrides: RawConfig = {};
+        if (verbose) {
+            cliOverrides.logLevel = 'verbose';
+        }
+
+        const config = await getConfig(cliOverrides);
         if (config.systemPromptPath) {
             try {
                 await fs.readFile(path.resolve(config.systemPromptPath), 'utf-8');

--- a/src/commands/prepare-commit-msg-hook.ts
+++ b/src/commands/prepare-commit-msg-hook.ts
@@ -44,7 +44,8 @@ export default (
     excludeFiles: string[],
     commitType: string | undefined,
     prompt: string | undefined,
-    includeBody: boolean | undefined
+    includeBody: boolean | undefined,
+    verbose: boolean
 ) =>
     (async () => {
         if (!messageFilePath) {
@@ -68,16 +69,19 @@ export default (
         const consoleManager = new ConsoleManager();
         consoleManager.printTitle();
 
-        const config = await getConfig(
-            {
-                locale: locale?.toString() as string,
-                generate: generate?.toString() as string,
-                type: commitType?.toString() as string,
-                systemPrompt: prompt?.toString() as string,
-                includeBody: includeBody?.toString() as string,
-            },
-            excludeFiles
-        );
+        const configOverrides: RawConfig = {
+            locale: locale?.toString() as string,
+            generate: generate?.toString() as string,
+            type: commitType?.toString() as string,
+            systemPrompt: prompt?.toString() as string,
+            includeBody: includeBody?.toString() as string,
+        };
+
+        if (verbose) {
+            configOverrides.logLevel = 'verbose';
+        }
+
+        const config = await getConfig(configOverrides, excludeFiles);
         if (config.systemPromptPath) {
             try {
                 await fs.readFile(path.resolve(config.systemPromptPath), 'utf-8');

--- a/src/managers/reactive-prompt.manager.ts
+++ b/src/managers/reactive-prompt.manager.ts
@@ -3,6 +3,7 @@ import inquirer from 'inquirer';
 import ReactiveListPrompt, { ChoiceItem, ReactiveListChoice, ReactiveListLoader } from 'inquirer-reactive-list-prompt';
 import { BehaviorSubject, ReplaySubject, Subscription } from 'rxjs';
 
+import { isVerboseLoggingEnabled } from '../utils/logger.js';
 import { sortByDisabled } from '../utils/utils.js';
 
 export const commitMsgLoader = {
@@ -164,7 +165,9 @@ export class ReactivePromptManager {
             this.subscriptions.unsubscribe();
             this.completeSubject();
         } catch (error) {
-            console.warn('Error during ReactivePromptManager destruction:', error);
+            if (isVerboseLoggingEnabled()) {
+                console.warn('Error during ReactivePromptManager destruction:', error);
+            }
         } finally {
             this.inquirerInstance = null;
         }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -7,6 +7,7 @@ import { AICOMMIT_EXCEPTION_LOG_FILE_PATH, AICOMMIT_MAIN_LOG_FILE_PATH } from '.
 import { ensureDirectoryExists } from './utils.js';
 
 let loggerInstance: winston.Logger | undefined = undefined;
+let currentLogLevel: string = 'info';
 
 export async function initializeLogger(options?: {
     logLevel?: string;
@@ -20,6 +21,7 @@ export async function initializeLogger(options?: {
     }
 
     const logLevel = options?.logLevel || 'info';
+    currentLogLevel = logLevel;
     const logFilePath = options?.logFilePath || AICOMMIT_MAIN_LOG_FILE_PATH;
     const exceptionLogFilePath = options?.exceptionLogFilePath || AICOMMIT_EXCEPTION_LOG_FILE_PATH;
     const logging = options?.logging ?? true; // Default to true
@@ -90,3 +92,13 @@ export const logger: winston.Logger = new Proxy({} as winston.Logger, {
         return Reflect.get(loggerInstance, prop, receiver);
     },
 });
+
+export function getCurrentLogLevel(): string {
+    return currentLogLevel;
+}
+
+export function isVerboseLoggingEnabled(): boolean {
+    const levels = winston.config.npm.levels;
+    const levelValue = levels[currentLogLevel] ?? levels.info;
+    return levelValue >= levels.verbose;
+}


### PR DESCRIPTION
I believe the change is positive as it changes the default behavior to suppressing the annoyance error message on macOS:

```
? Pick a commit message to use:  feat(buildkite): enhance agent configuration and monitoring
    [Gemini] feat(buildkite): support private repo access via SSH
    [ChatGPT] feat(aws): add SSH key handling and CloudWatch alarms
  ❯ [Anthropic] feat(buildkite): enhance agent configuration and monitoring

Error during ReactivePromptManager destruction: Error [ERR_USE_AFTER_CLOSE]: readline was closed
    at Interface.pause (node:internal/readline/interface:564:13)
    at PromptUI.close (file:///opt/homebrew/lib/node_modules/aicommit2/node_modules/inquirer/lib/ui/baseUI.js:55:13)
    at nr.closeInquirerInstance (file:///opt/homebrew/lib/node_modules/aicommit2/dist/cli.mjs:185:2083)
    at nr.destroy (file:///opt/homebrew/lib/node_modules/aicommit2/dist/cli.mjs:185:2268)
    at vc (file:///opt/homebrew/lib/node_modules/aicommit2/dist/cli.mjs:190:412)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async file:///opt/homebrew/lib/node_modules/aicommit2/dist/cli.mjs:186:1140 {
  code: 'ERR_USE_AFTER_CLOSE'
}
? Use selected message? Yes
```

If you find it compelling please merge, otherwise no worries!

I've already merged it into my fork here: https://github.com/jaytaylor/aicommit2/pull/1

---

p.s. thanks for aicommit2, it is very useful!