### PR TITLE
chore(nix): update flake.nix to version v2.4.13

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
       perSystem = {pkgs, ...}: {
         packages.default = pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
           pname = "aicommit2";
-          version = "v2.4.11";
+          version = "v2.4.13";
           src = self;
 
           pnpmDeps = pkgs.pnpm.fetchDeps {


### PR DESCRIPTION
This PR updates flake.nix with:
- New version: v2.4.13
- New hash: sha256-BkJZldFkAGqDsTQ2a/NM4W1vVGNzc1HysqeYFG25Hd4=

This update was performed automatically by a GitHub workflow.