### PR TITLE
Add env variable support in config.ini (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,18 @@ You can find the path of the currently loaded configuration file using the `conf
 aicommit2 config path
 ```
 
+#### Environment Variable Expansion in Config File
+
+You can use environment variables in your configuration file values. Both `$VAR` and `${VAR}` syntax are supported.
+
+Example `config.ini`:
+
+```ini
+[OPENAI]
+key=$OPENAI_API_KEY
+url=${CUSTOM_API_URL}/v1
+```
+
 #### Reading and Setting Configuration
 
 - READ: `aicommit2 config get [<key> [<key> ...]]`

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -5,6 +5,7 @@ describe('aicommit2', ({ runTestSuite }) => {
     runTestSuite(import('./specs/openai/index.js'));
     runTestSuite(import('./specs/bedrock/index.js'));
     runTestSuite(import('./specs/config.js'));
+    runTestSuite(import('./specs/config-env.js'));
     runTestSuite(import('./specs/git-hook.js'));
     runTestSuite(import('./specs/vcs/index.js'));
     runTestSuite(import('./specs/managers/index.js'));

--- a/tests/specs/config-env.ts
+++ b/tests/specs/config-env.ts
@@ -1,0 +1,42 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { expect, testSuite } from 'manten';
+import { createFixture } from '../utils.js';
+
+export default testSuite(({ describe }) => {
+    describe('config environment variable expansion', async ({ test }) => {
+        test('expands environment variables in config', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const configPath = path.join(fixture.path, '.aicommit2');
+
+            await fs.writeFile(configPath, '[OPENAI]\nurl=$MY_CUSTOM_URL\n');
+
+            const { stdout } = await aicommit2(['config', 'get', 'OPENAI.url'], {
+                env: {
+                    AICOMMIT_CONFIG_PATH: configPath,
+                    MY_CUSTOM_URL: 'https://api.custom.com',
+                },
+            });
+
+            expect(stdout).toMatch('https://api.custom.com');
+            await fixture.rm();
+        });
+
+        test('expands environment variables with curly braces', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const configPath = path.join(fixture.path, '.aicommit2');
+
+            await fs.writeFile(configPath, '[OPENAI]\nurl=${MY_CUSTOM_URL}/v1\n');
+
+            const { stdout } = await aicommit2(['config', 'get', 'OPENAI.url'], {
+                env: {
+                    AICOMMIT_CONFIG_PATH: configPath,
+                    MY_CUSTOM_URL: 'https://api.custom.com',
+                },
+            });
+
+            expect(stdout).toMatch('https://api.custom.com/v1');
+            await fixture.rm();
+        });
+    });
+});


### PR DESCRIPTION
* feat: add env variable support in config.ini

This commit adds support for expanding environment variables in the config.ini file. It supports both $VAR and ${VAR} syntax.


Close https://github.com/tak-bro/aicommit2/issues/213