### PR TITLE
Fix #235: Polish Copilot SDK support

### DIFF
--- a/src/services/ai/copilot-sdk.utils.ts
+++ b/src/services/ai/copilot-sdk.utils.ts
@@ -69,6 +69,9 @@ export const isCopilotSdkClassicPatError = (message: string): boolean => {
 export const buildCopilotSdkClientOptions = (env: NodeJS.ProcessEnv = process.env): CopilotSdkClientOptions => {
     const sanitizedEnv: NodeJS.ProcessEnv = { ...env };
 
+    // Suppress Node.js ExperimentalWarning (e.g., SQLite) in the Copilot CLI subprocess.
+    sanitizedEnv.NODE_NO_WARNINGS = '1';
+
     // Prevent COPILOT_SDK auth from being hijacked by generic GitHub token envs.
     delete sanitizedEnv.GH_TOKEN;
     delete sanitizedEnv.GITHUB_TOKEN;

--- a/tests/specs/copilot-sdk/utils.ts
+++ b/tests/specs/copilot-sdk/utils.ts
@@ -48,6 +48,11 @@ export default testSuite(({ describe }) => {
             expect(options.env?.GITHUB_TOKEN).toBe(undefined);
         });
 
+        test('sets NODE_NO_WARNINGS in env to suppress SQLite experimental warning in subprocess', () => {
+            const options = buildCopilotSdkClientOptions({});
+            expect(options.env?.NODE_NO_WARNINGS).toBe('1');
+        });
+
         test('builds client options using logged-in user when COPILOT_GITHUB_TOKEN is missing', () => {
             const options = buildCopilotSdkClientOptions({
                 GH_TOKEN: 'ghp_bad',


### PR DESCRIPTION
Closes #235

### Issue

#235

### Description

Suppresses the Node.js `ExperimentalWarning: SQLite is an experimental feature` that was leaking into CLI subprocess output from the Copilot SDK integration.

**Change:** In `src/services/ai/copilot-sdk.utils.ts`, `buildCopilotSdkClientOptions` now sets `NODE_NO_WARNINGS=1` in the sanitized environment passed to the Copilot CLI subprocess. This is applied before the existing `GH_TOKEN`/`GITHUB_TOKEN` deletions, ensuring the subprocess runs without emitting Node.js experimental feature warnings to stderr.

### Testing

Unit test added in `tests/specs/copilot-sdk/utils.ts`: `'sets NODE_NO_WARNINGS in env to suppress SQLite experimental warning in subprocess'` — calls `buildCopilotSdkClientOptions({})` and asserts `options.env?.NODE_NO_WARNINGS === '1'`.

### Additional context

`NODE_NO_WARNINGS=1` suppresses all Node.js process warnings in the subprocess, not just SQLite — this is acceptable since the warning output from the CLI subprocess is not user-actionable and was causing noise in aicommit2's output.

______________________________________________________________________

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*