### PR TITLE
fix(hooks): comment all lines of multi-line commit messages

### DIFF
--- a/src/commands/pre-commit-hook.ts
+++ b/src/commands/pre-commit-hook.ts
@@ -113,11 +113,21 @@ export default (
             instructions += '# ----------------------------------------\n';
         }
 
-        if (hasMultipleMessages) {
-            if (supportsComments) {
-                instructions += '\n# 📝 Choose one of these messages:\n';
-            }
-            instructions += `\n${messages.map(message => `# ${message}`).join('\n')}`;
+        if (hasMultipleMessages && supportsComments) {
+            instructions += '\n# 📝 Choose one of these messages:\n';
+            // Prefix every line of each message (not just the first), otherwise body/footer
+            // lines stay uncommented and git treats them as the actual commit body.
+            instructions += `\n${messages
+                .map(message =>
+                    message
+                        .split('\n')
+                        .map(line => `# ${line}`)
+                        .join('\n')
+                )
+                .join('\n#\n')}`;
+        } else if (hasMultipleMessages) {
+            // --no-edit: no editor to pick from, so auto-select the first message.
+            instructions += `\n${messages[0]}\n`;
         } else {
             if (supportsComments) {
                 instructions += '\n# 📝 Generated commit message:\n';

--- a/src/commands/prepare-commit-msg-hook.ts
+++ b/src/commands/prepare-commit-msg-hook.ts
@@ -145,11 +145,21 @@ export default (
             instructions += `${commentChar} ----------------------------------------\n`;
         }
 
-        if (hasMultipleMessages) {
-            if (supportsComments) {
-                instructions += `\n${commentChar} 📝 Choose one of these messages:\n`;
-            }
-            instructions += `\n${messages.map(message => `${commentChar} ${message}`).join('\n')}`;
+        if (hasMultipleMessages && supportsComments) {
+            instructions += `\n${commentChar} 📝 Choose one of these messages:\n`;
+            // Prefix every line of each message (not just the first), otherwise body/footer
+            // lines stay uncommented and git treats them as the actual commit body.
+            instructions += `\n${messages
+                .map(message =>
+                    message
+                        .split('\n')
+                        .map(line => `${commentChar} ${line}`)
+                        .join('\n')
+                )
+                .join(`\n${commentChar}\n`)}`;
+        } else if (hasMultipleMessages) {
+            // --no-edit: no editor to pick from, so auto-select the first message.
+            instructions += `\n${messages[0]}\n`;
         } else {
             if (supportsComments) {
                 instructions += `\n${commentChar} 📝 Generated commit message:\n`;


### PR DESCRIPTION
Fixes #237.

1. Comment every line of each option (editor mode)

When the editor opens, the picker needs every line of every candidate commented out so the user can pick one by removing just those # prefixes. Without this fix, the body/footer lines stay uncommented and git commits those as the message even if the user uncomments nothing.

2. Auto-pick the first when no editor (`--no-edit` mode)

There's no editor to pick in, so presenting a commented list produces an empty commit. Writes the first candidate as the actual message.