### PR TITLE
chore: simplify nix release workflow and add missing contributors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,174 +22,48 @@ jobs:
               uses: actions/checkout@v4
               with:
                   token: ${{ secrets.PAT_TOKEN }}
+                  fetch-depth: 0
+
+            - name: Check for releasable changes
+              id: check
+              run: |
+                  LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+                  if [ -n "$LATEST_TAG" ]; then
+                    CHANGED=$(git diff --name-only "$LATEST_TAG"..HEAD -- src/ package.json tsconfig.json)
+                    if [ -z "$CHANGED" ]; then
+                      echo "skip=true" >> "$GITHUB_OUTPUT"
+                      echo "No releasable code changes since $LATEST_TAG, skipping release"
+                    else
+                      echo "Releasable changes found since $LATEST_TAG:"
+                      echo "$CHANGED"
+                    fi
+                  fi
 
             - name: Setup Node.js
+              if: steps.check.outputs.skip != 'true'
               uses: actions/setup-node@v4
               with:
                   node-version-file: '.nvmrc'
 
             - name: Setup pnpm
+              if: steps.check.outputs.skip != 'true'
               uses: pnpm/action-setup@v2
               with:
                   version: 8
                   run_install: true
 
             - name: Semantic Release
+              if: steps.check.outputs.skip != 'true'
               id: semantic
               uses: cycjimmy/semantic-release-action@v4
               env:
                   GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    nix-hash-linux:
-        name: Compute Nix hash (x86_64-linux)
-        needs: release
-        if: needs.release.outputs.new_release_published == 'true'
-        runs-on: ubuntu-latest
-        outputs:
-            hash: ${{ steps.hash.outputs.hash }}
-
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
-              with:
-                  ref: main
-
-            - name: Install Nix
-              uses: cachix/install-nix-action@v26
-              with:
-                  nix_path: nixpkgs=channel:nixos-unstable
-
-            - name: Wait for NPM package availability
-              run: |
-                  VERSION="${{ needs.release.outputs.new_release_version }}"
-                  MAX_ATTEMPTS=12
-                  WAIT_SECONDS=10
-
-                  echo "Waiting for npm package aicommit2@${VERSION}..."
-
-                  for attempt in $(seq 1 $MAX_ATTEMPTS); do
-                    if npm view aicommit2@${VERSION} version >/dev/null 2>&1; then
-                      echo "Package aicommit2@${VERSION} is available"
-                      exit 0
-                    fi
-                    echo "Attempt $attempt/$MAX_ATTEMPTS: not yet available, waiting ${WAIT_SECONDS}s..."
-                    sleep $WAIT_SECONDS
-                  done
-
-                  echo "Package aicommit2@${VERSION} not available after $((MAX_ATTEMPTS * WAIT_SECONDS)) seconds"
-                  exit 1
-
-            - name: Extract pnpm deps hash
-              id: hash
-              run: |
-                  VERSION="v${{ needs.release.outputs.new_release_version }}"
-
-                  sed -i "s/version = \"v[^\"]*\";/version = \"${VERSION}\";/" flake.nix
-                  sed -i 's|"sha256-[A-Za-z0-9+/=]\{44\}"|"sha256-INVALIDHASHPLACEHOLDER000000000000000000000="|g' flake.nix
-
-                  MAX_ATTEMPTS=3
-                  HASH=""
-
-                  for attempt in $(seq 1 $MAX_ATTEMPTS); do
-                    echo "Build attempt $attempt/$MAX_ATTEMPTS for x86_64-linux..."
-                    nix_output=$(nix build .#packages.x86_64-linux.default 2>&1 || true)
-
-                    HASH=$(echo "$nix_output" | grep 'got:' | grep -oE 'sha256-[A-Za-z0-9+/=]{44}' | head -n1)
-
-                    if [[ -n "$HASH" && "$HASH" != *"INVALID"* ]]; then
-                      echo "Extracted hash: $HASH"
-                      break
-                    fi
-
-                    HASH=""
-                    echo "Attempt $attempt failed"
-                    [[ $attempt -lt $MAX_ATTEMPTS ]] && sleep 5
-                  done
-
-                  if [[ -z "$HASH" || "$HASH" == *"INVALID"* ]]; then
-                    echo "Failed to extract hash for x86_64-linux"
-                    exit 1
-                  fi
-
-                  echo "hash=${HASH}" >> "$GITHUB_OUTPUT"
-
-    nix-hash-darwin:
-        name: Compute Nix hash (aarch64-darwin)
-        needs: release
-        if: needs.release.outputs.new_release_published == 'true'
-        runs-on: macos-latest
-        outputs:
-            hash: ${{ steps.hash.outputs.hash }}
-
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
-              with:
-                  ref: main
-
-            - name: Install Nix
-              uses: cachix/install-nix-action@v26
-              with:
-                  nix_path: nixpkgs=channel:nixos-unstable
-
-            - name: Wait for NPM package availability
-              run: |
-                  VERSION="${{ needs.release.outputs.new_release_version }}"
-                  MAX_ATTEMPTS=12
-                  WAIT_SECONDS=10
-
-                  echo "Waiting for npm package aicommit2@${VERSION}..."
-
-                  for attempt in $(seq 1 $MAX_ATTEMPTS); do
-                    if npm view aicommit2@${VERSION} version >/dev/null 2>&1; then
-                      echo "Package aicommit2@${VERSION} is available"
-                      exit 0
-                    fi
-                    echo "Attempt $attempt/$MAX_ATTEMPTS: not yet available, waiting ${WAIT_SECONDS}s..."
-                    sleep $WAIT_SECONDS
-                  done
-
-                  echo "Package aicommit2@${VERSION} not available after $((MAX_ATTEMPTS * WAIT_SECONDS)) seconds"
-                  exit 1
-
-            - name: Extract pnpm deps hash
-              id: hash
-              run: |
-                  VERSION="v${{ needs.release.outputs.new_release_version }}"
-
-                  sed -i'' -e "s/version = \"v[^\"]*\";/version = \"${VERSION}\";/" flake.nix
-                  sed -i'' -e 's|"sha256-[A-Za-z0-9+/=]\{44\}"|"sha256-INVALIDHASHPLACEHOLDER000000000000000000000="|g' flake.nix
-
-                  MAX_ATTEMPTS=3
-                  HASH=""
-
-                  for attempt in $(seq 1 $MAX_ATTEMPTS); do
-                    echo "Build attempt $attempt/$MAX_ATTEMPTS for aarch64-darwin..."
-                    nix_output=$(nix build .#packages.aarch64-darwin.default 2>&1 || true)
-
-                    HASH=$(echo "$nix_output" | grep 'got:' | grep -oE 'sha256-[A-Za-z0-9+/=]{44}' | head -n1)
-
-                    if [[ -n "$HASH" && "$HASH" != *"INVALID"* ]]; then
-                      echo "Extracted hash: $HASH"
-                      break
-                    fi
-
-                    HASH=""
-                    echo "Attempt $attempt failed"
-                    [[ $attempt -lt $MAX_ATTEMPTS ]] && sleep 5
-                  done
-
-                  if [[ -z "$HASH" || "$HASH" == *"INVALID"* ]]; then
-                    echo "Failed to extract hash for aarch64-darwin"
-                    exit 1
-                  fi
-
-                  echo "hash=${HASH}" >> "$GITHUB_OUTPUT"
-
     update-nix:
         name: Update Nix Flake
-        needs: [release, nix-hash-linux, nix-hash-darwin]
+        needs: release
+        if: needs.release.outputs.new_release_published == 'true'
         runs-on: ubuntu-latest
         permissions:
             contents: write
@@ -206,43 +80,85 @@ jobs:
               with:
                   nix_path: nixpkgs=channel:nixos-unstable
 
-            - name: Update flake.nix with all hashes
+            - name: Wait for NPM package availability
+              run: |
+                  VERSION="${{ needs.release.outputs.new_release_version }}"
+                  MAX_ATTEMPTS=12
+                  WAIT_SECONDS=10
+
+                  echo "Waiting for npm package aicommit2@${VERSION}..."
+
+                  for attempt in $(seq 1 $MAX_ATTEMPTS); do
+                    if npm view aicommit2@${VERSION} version >/dev/null 2>&1; then
+                      echo "Package aicommit2@${VERSION} is available"
+                      exit 0
+                    fi
+                    echo "Attempt $attempt/$MAX_ATTEMPTS: not yet available, waiting ${WAIT_SECONDS}s..."
+                    sleep $WAIT_SECONDS
+                  done
+
+                  echo "Package aicommit2@${VERSION} not available after $((MAX_ATTEMPTS * WAIT_SECONDS)) seconds"
+                  exit 1
+
+            - name: Update flake.nix
               run: |
                   VERSION="v${{ needs.release.outputs.new_release_version }}"
-                  HASH_X86_64_LINUX="${{ needs.nix-hash-linux.outputs.hash }}"
-                  HASH_AARCH64_DARWIN="${{ needs.nix-hash-darwin.outputs.hash }}"
-
                   echo "Updating flake.nix to version: $VERSION"
-                  echo "  x86_64-linux hash:   $HASH_X86_64_LINUX"
-                  echo "  aarch64-darwin hash: $HASH_AARCH64_DARWIN"
 
-                  # Validate hash format
-                  HASH_REGEX='^sha256-[A-Za-z0-9+/=]{44}$'
-                  if [[ ! "$HASH_X86_64_LINUX" =~ $HASH_REGEX ]]; then
-                    echo "Invalid x86_64-linux hash: $HASH_X86_64_LINUX"
-                    exit 1
-                  fi
-                  if [[ ! "$HASH_AARCH64_DARWIN" =~ $HASH_REGEX ]]; then
-                    echo "Invalid aarch64-darwin hash: $HASH_AARCH64_DARWIN"
-                    exit 1
-                  fi
+                  # Backup current flake.nix
+                  cp flake.nix flake.nix.backup
 
                   # Update version
                   sed -i "s/version = \"v[^\"]*\";/version = \"${VERSION}\";/" flake.nix
 
-                  # Update per-system hashes
-                  sed -i "s|\"x86_64-linux\" = \"sha256-[^\"]*\";|\"x86_64-linux\" = \"${HASH_X86_64_LINUX}\";|" flake.nix
-                  sed -i "s|\"aarch64-darwin\" = \"sha256-[^\"]*\";|\"aarch64-darwin\" = \"${HASH_AARCH64_DARWIN}\";|" flake.nix
+                  # Force invalid hash to trigger mismatch
+                  sed -i 's|hash = "sha256-[^"]*";|hash = "sha256-INVALIDHASHPLACEHOLDER000000000000000000000=";|' flake.nix
 
-                  # Validate
-                  echo "Validating flake.nix..."
-                  if ! nix flake check --no-build 2>&1; then
-                    echo "Flake validation failed"
+                  # Build to get correct hash with retry logic
+                  MAX_ATTEMPTS=3
+                  HASH=""
+
+                  for attempt in $(seq 1 $MAX_ATTEMPTS); do
+                    echo "Build attempt $attempt/$MAX_ATTEMPTS..."
+                    nix_output=$(nix build .#packages.x86_64-linux.default 2>&1 || true)
+
+                    HASH=$(echo "$nix_output" | grep 'got:' | grep -oE 'sha256-[A-Za-z0-9+/=]{44}' | head -n1)
+
+                    if [[ -n "$HASH" && "$HASH" != *"INVALID"* ]]; then
+                      echo "Extracted hash: $HASH"
+                      break
+                    fi
+
+                    HASH=""
+                    echo "Attempt $attempt failed"
+                    [[ $attempt -lt $MAX_ATTEMPTS ]] && sleep 5
+                  done
+
+                  # Validate hash was extracted
+                  if [[ -z "$HASH" || "$HASH" == *"INVALID"* ]]; then
+                    echo "Failed to extract valid hash after $MAX_ATTEMPTS attempts"
+                    echo "Nix build output:"
+                    echo "$nix_output"
+                    mv flake.nix.backup flake.nix
                     exit 1
                   fi
 
+                  # Update with correct hash
+                  sed -i "s|hash = \"sha256-[^\"]*\";|hash = \"${HASH}\";|" flake.nix
+
+                  # Validate the updated flake
+                  echo "Validating flake.nix..."
+                  if ! nix flake check --no-build 2>&1; then
+                    echo "Flake validation failed"
+                    mv flake.nix.backup flake.nix
+                    exit 1
+                  fi
+
+                  rm -f flake.nix.backup
+
                   echo "Changes:"
                   git diff flake.nix
+                  echo "Update complete: $VERSION with hash $HASH"
 
             - name: Commit and push
               run: |

--- a/README.md
+++ b/README.md
@@ -1272,6 +1272,14 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/totoroot"><img src="https://avatars.githubusercontent.com/totoroot" width="100px;" alt=""/><br /><sub><b>@totoroot</b></sub></a><br /><a href="https://github.com/tak-bro/aicommit2/commits?author=totoroot" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/lawrence3699"><img src="https://avatars.githubusercontent.com/lawrence3699" width="100px;" alt=""/><br /><sub><b>@lawrence3699</b></sub></a><br /><a href="https://github.com/tak-bro/aicommit2/commits?author=lawrence3699" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/atlet99"><img src="https://avatars.githubusercontent.com/atlet99" width="100px;" alt=""/><br /><sub><b>@atlet99</b></sub></a><br /><a href="https://github.com/tak-bro/aicommit2/commits?author=atlet99" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/HoChihchou"><img src="https://avatars.githubusercontent.com/HoChihchou" width="100px;" alt=""/><br /><sub><b>@HoChihchou</b></sub></a><br /><a href="https://github.com/tak-bro/aicommit2/commits?author=HoChihchou" title="Code">💻</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/chenmi319"><img src="https://avatars.githubusercontent.com/chenmi319" width="100px;" alt=""/><br /><sub><b>@chenmi319</b></sub></a><br /><a href="https://github.com/tak-bro/aicommit2/commits?author=chenmi319" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/JiwaniZakir"><img src="https://avatars.githubusercontent.com/JiwaniZakir" width="100px;" alt=""/><br /><sub><b>@JiwaniZakir</b></sub></a><br /><a href="https://github.com/tak-bro/aicommit2/commits?author=JiwaniZakir" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/qistchan"><img src="https://avatars.githubusercontent.com/qistchan" width="100px;" alt=""/><br /><sub><b>@qistchan</b></sub></a><br /><a href="https://github.com/tak-bro/aicommit2/commits?author=qistchan" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/Cassius0924"><img src="https://avatars.githubusercontent.com/Cassius0924" width="100px;" alt=""/><br /><sub><b>@Cassius0924</b></sub></a><br /><a href="https://github.com/tak-bro/aicommit2/commits?author=Cassius0924" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/Xyhlon"><img src="https://avatars.githubusercontent.com/Xyhlon" width="100px;" alt=""/><br /><sub><b>@Xyhlon</b></sub></a><br /><a href="https://github.com/tak-bro/aicommit2/commits?author=Xyhlon" title="Code">💻</a></td>
   </tr>
 </table>
 <!-- markdownlint-restore -->

--- a/scripts/update-nix-hash.sh
+++ b/scripts/update-nix-hash.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
-# Script to update flake.nix version and per-system pnpm deps hash
+# Script to update flake.nix version and hash
 # Usage: ./scripts/update-nix-hash.sh [version]
 # Example: ./scripts/update-nix-hash.sh v2.4.9
-#
-# Detects the current system (x86_64-linux or aarch64-darwin) and updates
-# only that system's hash in the pnpmDepsHash map.
 
 set -e
 
@@ -18,17 +15,6 @@ NC='\033[0m' # No Color
 if ! command -v nix &>/dev/null; then
     echo -e "${RED}✗ Error: nix is not installed${NC}"
     echo "Please install nix from https://nixos.org/download.html"
-    exit 1
-fi
-
-# Detect current system
-SYSTEM=$(nix eval --impure --raw --expr 'builtins.currentSystem')
-echo -e "${GREEN}✓ Detected system: ${SYSTEM}${NC}"
-
-# Validate supported system
-if [[ $SYSTEM != "x86_64-linux" && $SYSTEM != "aarch64-darwin" ]]; then
-    echo -e "${RED}✗ Unsupported system: ${SYSTEM}${NC}"
-    echo "Supported systems: x86_64-linux, aarch64-darwin"
     exit 1
 fi
 
@@ -47,7 +33,7 @@ if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     exit 1
 fi
 
-echo "Updating flake.nix to version ${VERSION} (hash for ${SYSTEM})..."
+echo "Updating flake.nix to version ${VERSION}..."
 
 # Backup original file
 cp flake.nix flake.nix.backup
@@ -58,13 +44,13 @@ sed -i.tmp "s/version = \"v[0-9.]*\";/version = \"${VERSION}\";/" flake.nix
 rm -f flake.nix.tmp
 echo -e "${GREEN}✓ Updated version to ${VERSION}${NC}"
 
-# Set invalid hash for current system to trigger mismatch
-sed -i.tmp "s|\"${SYSTEM}\" = \"sha256-[^\"]*\";|\"${SYSTEM}\" = \"sha256-INVALIDHASHPLACEHOLDER000000000000000000000=\";|" flake.nix
+# Set a known bad hash to trigger mismatch
+sed -i.tmp 's|hash = "sha256-[^"]*";|hash = "sha256-INVALIDHASHPLACEHOLDER000000000000000000000=";|' flake.nix
 rm -f flake.nix.tmp
 
 # Build and capture the correct hash
-echo "Building to calculate correct hash for ${SYSTEM} (this will fail, that's expected)..."
-BUILD_OUTPUT=$(nix build ".#packages.${SYSTEM}.default" 2>&1 || true)
+echo "Building to calculate correct hash (this will fail, that's expected)..."
+BUILD_OUTPUT=$(nix build --print-out-paths 2>&1 || true)
 
 # Extract the correct hash from error message
 CORRECT_HASH=$(echo "$BUILD_OUTPUT" | grep 'got:' | grep -oE 'sha256-[A-Za-z0-9+/=]{44}' | head -n1)
@@ -80,16 +66,16 @@ if [ -z "$CORRECT_HASH" ]; then
     exit 1
 fi
 
-echo -e "${GREEN}✓ Calculated hash for ${SYSTEM}: ${CORRECT_HASH}${NC}"
+echo -e "${GREEN}✓ Calculated hash: ${CORRECT_HASH}${NC}"
 
-# Update hash for current system in flake.nix
-sed -i.tmp "s|\"${SYSTEM}\" = \"sha256-[^\"]*\";|\"${SYSTEM}\" = \"${CORRECT_HASH}\";|" flake.nix
+# Update hash in flake.nix
+sed -i.tmp "s|hash = \"sha256-[^\"]*\";|hash = \"${CORRECT_HASH}\";|" flake.nix
 rm -f flake.nix.tmp
-echo -e "${GREEN}✓ Updated ${SYSTEM} hash in flake.nix${NC}"
+echo -e "${GREEN}✓ Updated hash in flake.nix${NC}"
 
 # Verify the build works
 echo "Verifying build with new hash..."
-if nix build ".#packages.${SYSTEM}.default" --print-out-paths >/dev/null 2>&1; then
+if nix build --print-out-paths >/dev/null 2>&1; then
     echo -e "${GREEN}✓ Build successful!${NC}"
 
     # Remove backup
@@ -99,8 +85,7 @@ if nix build ".#packages.${SYSTEM}.default" --print-out-paths >/dev/null 2>&1; t
     echo -e "${GREEN}==================================${NC}"
     echo -e "${GREEN}Successfully updated flake.nix:${NC}"
     echo -e "  Version: ${VERSION}"
-    echo -e "  System:  ${SYSTEM}"
-    echo -e "  Hash:    ${CORRECT_HASH}"
+    echo -e "  Hash: ${CORRECT_HASH}"
     echo -e "${GREEN}==================================${NC}"
     echo ""
     echo "You can now commit these changes:"


### PR DESCRIPTION
- Revert release.yml to single-job nix hash update (fetcherVersion 3 makes per-system hashes unnecessary)
- Add releasable changes check to skip npm publish when only non-source files change (flake.nix, scripts/, .github/)
- Revert update-nix-hash.sh to single hash pattern
- Add 6 missing contributors to README

### Issue

Issue number, if available, prefixed with "#"

### Description

What does this implement/fix? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

______________________________________________________________________

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
