### PR TITLE
feat: add rewrite command for commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ _aicommit2_ automatically generates commit messages using AI. It supports [Git](
 - **[OpenAI API Compatibility](docs/providers/compatible.md)**: Support for any service that implements the OpenAI API specification
 - **[Reactive CLI](#usage)**: Enables simultaneous requests to multiple AIs and selection of the best commit message
 - **[Code Review](#code-review)**: AI-powered structured code review with severity levels before committing
+- **[Commit Rewrite](#usage)**: Rewrite the commit message of any existing commit with AI (`aicommit2 rewrite`)
 - **[Git Hook Integration](#git-hooks)**: Can be used as a prepare-commit-msg hook
 - **[Custom Prompt](#custom-prompt-template)**: Supports user-defined system prompt templates
 - **[Diff Compression](#diff-compression)**: Reduces token usage by 30-60% with smart diff compression
@@ -454,6 +455,7 @@ In addition to the main commit message generation, aicommit2 provides several ut
 | `aicommit2 config` | Manage configuration (get, set, list, del) |
 | `aicommit2 doctor` | Check health status of AI providers |
 | `aicommit2 stats` | View usage statistics and performance metrics |
+| `aicommit2 rewrite` | Rewrite the commit message of any commit using AI |
 | `aicommit2 hook` | Install/uninstall Git prepare-commit-msg hook |
 | `aicommit2 log` | Manage log files |
 | `aicommit2 github-login` | Login to GitHub for GitHub Models access |
@@ -478,6 +480,11 @@ aicommit2 stats clear   # Clear all stats
 # Git hook
 aicommit2 hook install
 aicommit2 hook uninstall
+
+# Rewrite commit message
+aicommit2 rewrite                 # Rewrite HEAD commit message
+aicommit2 rewrite abc1234         # Rewrite specific commit
+aicommit2 rewrite HEAD~2 --dry-run   # Preview without rewriting
 ```
 
 > GitHub Models tip: use `aicommit2 github-login` and set `GITHUB_MODELS.model` in `publisher/model` format (for example, `openai/gpt-5`).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import hookCommand, { isCalledFromGitHook } from './commands/hook.js';
 import logCommand from './commands/log.js';
 import preCommitHook from './commands/pre-commit-hook.js';
 import prepareCommitMessageHook from './commands/prepare-commit-msg-hook.js';
+import rewriteCommand from './commands/rewrite.js';
 import setupCommand from './commands/setup.js';
 import { statsCommand } from './commands/stats.js';
 import { watchGit } from './commands/watch-git.js';
@@ -154,7 +155,7 @@ cli(
             },
         },
 
-        commands: [configCommand, doctorCommand, githubLoginCommand, hookCommand, logCommand, setupCommand, statsCommand],
+        commands: [configCommand, doctorCommand, githubLoginCommand, hookCommand, logCommand, rewriteCommand, setupCommand, statsCommand],
 
         help: {
             description,

--- a/src/commands/rewrite.ts
+++ b/src/commands/rewrite.ts
@@ -1,0 +1,391 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { command } from 'cleye';
+import { execa } from 'execa';
+import inquirer from 'inquirer';
+import { ReactiveListChoice } from 'inquirer-reactive-list-prompt';
+
+import { getAvailableAIs } from './get-available-ais.js';
+import { AIRequestManager } from '../managers/ai-request.manager.js';
+import { ConsoleManager } from '../managers/console.manager.js';
+import { ReactivePromptManager, commitMsgLoader } from '../managers/reactive-prompt.manager.js';
+import { RawConfig, applyDisableLowerCaseToConfig, getConfig } from '../utils/config.js';
+import { ErrorCode, ErrorMessages } from '../utils/error-messages.js';
+import { KnownError, handleCliError } from '../utils/error.js';
+import { initializeLogger } from '../utils/logger.js';
+import { validateSystemPrompt } from '../utils/prompt.js';
+import {
+    applyDiffCompression,
+    assertGitRepo,
+    getBranchName,
+    getCommitDiff,
+    getCommitMessage,
+    getRecentCommits,
+    getVCSName,
+    isCommitPushed,
+    rewriteCommit as vcsRewriteCommit,
+} from '../utils/vcs.js';
+
+import type { Subscription } from 'rxjs';
+
+const consoleManager = new ConsoleManager();
+
+/**
+ * Extended ReactiveListChoice with provider metadata for selection tracking
+ */
+interface RewriteChoice extends ReactiveListChoice {
+    provider?: string;
+    model?: string;
+}
+
+export default command(
+    {
+        name: 'rewrite',
+        parameters: ['[commit-hash]'],
+        help: {
+            description: 'Rewrite the commit message of a commit using AI (defaults to HEAD)',
+            examples: ['aicommit2 rewrite', 'aicommit2 rewrite -g 3', 'aicommit2 rewrite abc1234', 'aicommit2 rewrite HEAD~2 --dry-run'],
+        },
+        flags: {
+            locale: {
+                type: String,
+                description: 'Locale to use for the generated commit messages (default: en)',
+                alias: 'l',
+            },
+            generate: {
+                type: Number,
+                description: 'Number of messages to generate (default: 1)',
+                alias: 'g',
+            },
+            type: {
+                type: String,
+                description: 'Type of commit message to generate (default: conventional)',
+                alias: 't',
+            },
+            confirm: {
+                type: Boolean,
+                description: 'Skip confirmation when rewriting after message generation (default: false)',
+                alias: 'y',
+                default: false,
+            },
+            prompt: {
+                type: String,
+                description: 'Custom prompt to fine-tune the generated message',
+                alias: 'p',
+            },
+            'auto-select': {
+                type: Boolean,
+                description: 'Automatically select the message when only one is generated',
+                alias: 's',
+                default: false,
+            },
+            edit: {
+                type: Boolean,
+                description: 'Open the AI-generated commit message in your default editor',
+                alias: 'e',
+                default: false,
+            },
+            verbose: {
+                type: Boolean,
+                description: 'Enable verbose logging for this run',
+                alias: 'v',
+                default: false,
+            },
+            'dry-run': {
+                type: Boolean,
+                description: 'Generate commit message without rewriting (output only)',
+                alias: 'd',
+                default: false,
+            },
+            'disable-lowercase': {
+                type: Boolean,
+                description: 'Disable automatic lowercase conversion of commit messages',
+                default: false,
+            },
+        },
+    },
+    argv => {
+        (async () => {
+            consoleManager.printTitle();
+
+            // Detect repository
+            const initSpinner = consoleManager.displaySpinner('Detecting repository...');
+            await assertGitRepo();
+
+            // Verify we're in a Git repo (rewrite only supported for Git)
+            const vcsName = await getVCSName();
+            if (vcsName !== 'git') {
+                throw new KnownError(
+                    `Rewrite is only supported for Git repositories. Current VCS: ${vcsName}.\n\n` +
+                        'For Jujutsu, use: jj describe -m "new message"\n' +
+                        'For YADM, use: yadm commit --amend -m "new message"'
+                );
+            }
+
+            // Resolve commit hash (default to HEAD)
+            const commitHash: string = argv._.commitHash || 'HEAD';
+
+            // Validate commit hash if not HEAD
+            if (commitHash !== 'HEAD') {
+                initSpinner.text = 'Validating commit reference...';
+                try {
+                    await execa('git', ['rev-parse', '--verify', `${commitHash}^{commit}`]);
+                } catch {
+                    throw new KnownError(
+                        `Invalid commit reference: ${commitHash}.\n\n` +
+                            'Provide a valid commit hash, branch name, or relative reference (e.g., HEAD~2).'
+                    );
+                }
+            }
+
+            initSpinner.text = 'Loading configuration...';
+
+            const configOverrides: RawConfig = {
+                locale: argv.flags.locale?.toString() as string,
+                generate: argv.flags.generate?.toString() as string,
+                type: argv.flags.type?.toString() as string,
+                systemPrompt: argv.flags.prompt?.toString() as string,
+                ...(argv.flags['disable-lowercase'] === true && { disableLowerCase: 'true' }),
+            };
+
+            if (argv.flags.verbose) {
+                configOverrides.logLevel = 'verbose';
+            }
+
+            const config = await getConfig(configOverrides, []);
+
+            await initializeLogger(config);
+
+            if (argv.flags['disable-lowercase']) {
+                applyDisableLowerCaseToConfig(config);
+            }
+
+            await validateSystemPrompt(config);
+
+            // Get the target commit's diff and current message
+            initSpinner.text = 'Reading commit information...';
+            const commitDiff = await getCommitDiff(commitHash);
+            initSpinner.stop();
+
+            if (!commitDiff) {
+                throw new KnownError(
+                    `Could not retrieve the diff for commit ${commitHash}.\n\n` +
+                        'Make sure the commit hash is correct and the commit exists.',
+                    { code: ErrorCode.VCS_NOT_FOUND }
+                );
+            }
+
+            const currentMessage = await getCommitMessage(commitHash);
+            if (!currentMessage) {
+                throw new KnownError(
+                    `Could not retrieve the commit message for ${commitHash}.\n\n` +
+                        'Make sure the commit hash is correct and the commit exists.'
+                );
+            }
+
+            // Show current message and diff summary
+            const isHead = commitHash === 'HEAD';
+            consoleManager.printInfo(`${isHead ? 'Current' : `Commit ${commitHash}`} commit message:\n  ${currentMessage}\n`);
+            const preview = applyDiffCompression(commitDiff, {
+                mode: config.diffCompression,
+                maxHunkLines: config.maxHunkLines,
+                maxDiffLines: config.maxDiffLines,
+            });
+            consoleManager.printStagedFiles(commitDiff, preview.compression);
+
+            // Get available AIs for commit message generation
+            const availableAIs = getAvailableAIs(config, 'commit');
+            if (availableAIs.length === 0) {
+                throw new KnownError(ErrorMessages.noApiKeysConfigured(), {
+                    code: ErrorCode.MISSING_API_KEY,
+                });
+            }
+
+            const branchName = await getBranchName();
+            const recentCommits = await getRecentCommits();
+            const aiRequestManager = new AIRequestManager(config, commitDiff, branchName, recentCommits);
+
+            const autoSelect = argv.flags['auto-select'] || false;
+            const edit = argv.flags.edit || false;
+            const confirm = argv.flags.confirm || false;
+            const dryRun = argv.flags['dry-run'] || false;
+
+            // Generate and select new commit message
+            const commitMsgPromptManager = new ReactivePromptManager(commitMsgLoader);
+            let commitMsgSubscription: Subscription | null = null;
+
+            try {
+                // Store choices with metadata for later lookup
+                const choiceMap = new Map<string, RewriteChoice>();
+
+                const commitMsgInquirer = commitMsgPromptManager.initPrompt();
+
+                commitMsgPromptManager.startLoader();
+
+                let receivedCount = 0;
+
+                commitMsgSubscription = aiRequestManager.createCommitMsgRequests$(availableAIs).subscribe({
+                    next: (choice: ReactiveListChoice) => {
+                        const rewriteChoice = choice as RewriteChoice;
+                        if (rewriteChoice.value) {
+                            choiceMap.set(rewriteChoice.value, rewriteChoice);
+                        }
+
+                        const isValidResponse = choice.value && !choice.isError && !choice.disabled;
+                        if (isValidResponse) {
+                            receivedCount++;
+                            commitMsgPromptManager.updateLoaderText(
+                                `AI is analyzing your changes (${receivedCount} message${receivedCount > 1 ? 's' : ''} generated)`
+                            );
+                        }
+
+                        commitMsgPromptManager.refreshChoices(choice);
+                    },
+                    error: error => {
+                        console.error('Commit message generation error:', error);
+                        commitMsgPromptManager.checkErrorOnChoices();
+                    },
+                    complete: () => commitMsgPromptManager.checkErrorOnChoices(),
+                });
+
+                const commitMsgInquirerResult = await commitMsgInquirer;
+
+                const selectedValue = commitMsgInquirerResult.aicommit2Prompt?.value;
+                if (!selectedValue) {
+                    throw new KnownError('An error occurred! No selected message');
+                }
+
+                const selectedChoice = choiceMap.get(selectedValue);
+                let selectedMessage = selectedValue;
+
+                if (edit) {
+                    consoleManager.printInfo('Opening editor to modify commit message...');
+                    selectedMessage = await openEditor(selectedMessage);
+
+                    if (!selectedMessage.trim()) {
+                        throw new KnownError(ErrorMessages.emptyCommitMessage(), {
+                            code: ErrorCode.EMPTY_COMMIT_MESSAGE,
+                        });
+                    }
+
+                    consoleManager.printSuccess('Commit message edited successfully!');
+                    consoleManager.print(`\n${selectedMessage}\n`);
+                }
+
+                // Dry run: output only, don't rewrite
+                if (dryRun) {
+                    process.stdout.write(selectedMessage + '\n');
+                    process.exit();
+                }
+
+                // Auto-select or confirm
+                if (confirm || (autoSelect && availableAIs.length === 1)) {
+                    await performRewrite(selectedMessage, commitHash);
+                    process.exit();
+                }
+
+                const { confirmationPrompt } = await inquirer.prompt([
+                    {
+                        type: 'confirm',
+                        name: 'confirmationPrompt',
+                        message: `Use selected message?`,
+                        default: true,
+                    },
+                ]);
+
+                if (confirmationPrompt) {
+                    await performRewrite(selectedMessage, commitHash);
+                } else {
+                    consoleManager.printCancelledCommit();
+                }
+                process.exit();
+            } finally {
+                if (commitMsgSubscription) {
+                    commitMsgSubscription.unsubscribe();
+                }
+                commitMsgPromptManager.destroy();
+            }
+        })().catch(error => {
+            consoleManager.printError(error.message);
+            handleCliError(error);
+            process.exit(1);
+        });
+    }
+);
+
+/**
+ * Rewrite the commit message, with a push warning.
+ */
+async function performRewrite(message: string, commitHash: string): Promise<void> {
+    const pushed = await isCommitPushed(commitHash);
+    if (pushed) {
+        const isHead = commitHash === 'HEAD';
+        consoleManager.printWarning(
+            `⚠  ${isHead ? 'The HEAD' : `Commit ${commitHash.slice(0, 7)}`} appears to have been pushed to the remote.\n` +
+                '   Rewriting will change its hash. You will need to force push:\n' +
+                '     git push --force-with-lease'
+        );
+
+        const { proceed } = await inquirer.prompt([
+            {
+                type: 'confirm',
+                name: 'proceed',
+                message: 'Continue with rewrite anyway?',
+                default: false,
+            },
+        ]);
+
+        if (!proceed) {
+            consoleManager.printCancelledCommit();
+            process.exit();
+        }
+    }
+
+    await vcsRewriteCommit(message, commitHash);
+    consoleManager.printSuccess('Commit message rewritten successfully!');
+}
+
+/**
+ * Open the commit message in the user's default editor for editing.
+ */
+async function openEditor(message: string): Promise<string> {
+    const editor = process.env.VISUAL || process.env.EDITOR || (process.platform === 'win32' ? 'notepad' : 'vi');
+    const tempFile = path.join(os.tmpdir(), `aicommit2-rewrite-${Date.now()}-${crypto.randomBytes(4).toString('hex')}.txt`);
+
+    try {
+        fs.writeFileSync(tempFile, message, 'utf8');
+
+        const editorParts = editor.split(' ');
+        const [binary, ...flags] = editorParts;
+
+        await execa(binary, [...flags, tempFile], { stdio: 'inherit' });
+
+        const editedMessage = fs.readFileSync(tempFile, 'utf8').trim();
+        fs.unlinkSync(tempFile);
+
+        if (!editedMessage) {
+            throw new KnownError('Rewrite cancelled - empty message');
+        }
+
+        return editedMessage;
+    } catch (error) {
+        if (fs.existsSync(tempFile)) {
+            fs.unlinkSync(tempFile);
+        }
+
+        if (error instanceof KnownError) {
+            throw error;
+        }
+
+        if (error && typeof error === 'object' && 'exitCode' in error) {
+            if ((error as any).exitCode !== 0) {
+                throw new KnownError('Rewrite cancelled');
+            }
+        }
+
+        throw new KnownError(`Failed to open editor "${editor}". Please set your EDITOR or VISUAL environment variable.`);
+    }
+}

--- a/src/utils/vcs-adapters/base.adapter.ts
+++ b/src/utils/vcs-adapters/base.adapter.ts
@@ -45,6 +45,21 @@ export abstract class BaseVCSAdapter {
     abstract commit(message: string, args?: string[], options?: CommitOptions): Promise<void>;
 
     /**
+     * Rewrite the commit message of a specific commit (defaults to HEAD)
+     */
+    abstract rewriteCommit?(message: string, commitHash?: string): Promise<void>;
+
+    /**
+     * Get the commit message of a specific commit
+     */
+    abstract getCommitMessage?(commitHash?: string): Promise<string>;
+
+    /**
+     * Check if a commit has been pushed to upstream
+     */
+    abstract isCommitPushed?(commitHash?: string): Promise<boolean>;
+
+    /**
      * Get the comment character used for commit messages
      */
     abstract getCommentChar(): Promise<string>;

--- a/src/utils/vcs-adapters/git.adapter.ts
+++ b/src/utils/vcs-adapters/git.adapter.ts
@@ -1,3 +1,7 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
 import { execa } from 'execa';
 
 import { DEFAULT_DIFF_CONTEXT } from '../diff-compressor.js';
@@ -233,6 +237,104 @@ export class GitAdapter extends BaseVCSAdapter {
             return branchName;
         } catch {
             return 'HEAD';
+        }
+    }
+
+    /**
+     * Get the commit message of a specific commit (defaults to HEAD).
+     */
+    async getCommitMessage(commitHash: string = 'HEAD'): Promise<string> {
+        try {
+            const { stdout } = await execa('git', ['log', '--format=%B', '-n', '1', commitHash]);
+            return stdout.trim();
+        } catch {
+            return '';
+        }
+    }
+
+    /**
+     * Rewrite the commit message of a specific commit.
+     * For HEAD: uses `git commit --amend`.
+     * For non-HEAD: uses `git rebase -i` with GIT_SEQUENCE_EDITOR + GIT_EDITOR.
+     */
+    async rewriteCommit(message: string, commitHash: string = 'HEAD'): Promise<void> {
+        try {
+            if (commitHash === 'HEAD') {
+                // --only --allow-empty: amend only the message, ignoring any staged changes
+                // Without --only, git commit --amend folds staged content into the commit
+                await execa('git', ['commit', '--amend', '--only', '--allow-empty', '-m', message], {
+                    stdio: 'inherit',
+                });
+            } else {
+                // Resolve symbolic references (HEAD~1, branch names) to abbreviated commit hash
+                // The rebase todo list uses actual commit hashes, not symbolic names
+                const { stdout: shortHash } = await execa('git', ['rev-parse', '--short', commitHash]);
+                const resolvedHash = shortHash.trim();
+
+                // Write new message to a temp file for GIT_EDITOR to copy
+                const tmpFile = path.join(os.tmpdir(), `aicommit2-rewrite-msg-${Date.now()}.txt`);
+                fs.writeFileSync(tmpFile, message, 'utf8');
+
+                // Determine sed in-place flag for the platform
+                const sedInPlace = process.platform === 'darwin' ? "sed -i ''" : 'sed -i';
+
+                try {
+                    // GIT_SEQUENCE_EDITOR: change 'pick' to 'reword' for the target commit
+                    // GIT_EDITOR: copy the new message file to the commit message file ($1)
+                    await execa('git', ['rebase', '-i', `${commitHash}^`, '--keep-empty'], {
+                        env: {
+                            ...process.env,
+                            GIT_SEQUENCE_EDITOR: `${sedInPlace} 's/^pick ${resolvedHash}/reword ${resolvedHash}/'`,
+                            GIT_EDITOR: `sh -c 'cp "${tmpFile}" "$1"' --`,
+                        },
+                        stdio: 'inherit',
+                    });
+                } finally {
+                    // Clean up temp file
+                    if (fs.existsSync(tmpFile)) {
+                        fs.unlinkSync(tmpFile);
+                    }
+                }
+            }
+        } catch (error) {
+            const execError = error as any;
+
+            if (execError.stderr) {
+                if (execError.stderr.includes('Author identity unknown')) {
+                    throw new KnownError(
+                        'Git author identity not configured.\n\nConfigure with:\n  git config --global user.name "Your Name"\n  git config --global user.email "your.email@example.com"'
+                    );
+                }
+                if (execError.stderr.includes('nothing to amend')) {
+                    throw new KnownError('Nothing to amend. The specified commit has no changes to modify.');
+                }
+                if (execError.stderr.includes('fatal: invalid upstream')) {
+                    throw new KnownError(
+                        `Invalid commit reference: ${commitHash}.\n\n` +
+                            'Make sure the commit hash is correct and the commit exists in this repository.'
+                    );
+                }
+                throw new KnownError(`Git rewrite failed: ${execError.stderr.trim()}`);
+            }
+
+            throw new KnownError(`Failed to rewrite commit: ${execError.message || 'Unknown error'}`);
+        }
+    }
+
+    /**
+     * Check if a commit has been pushed to the remote tracking branch.
+     */
+    async isCommitPushed(commitHash: string = 'HEAD'): Promise<boolean> {
+        try {
+            const { stdout: upstream } = await execa('git', ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}']);
+            if (!upstream.trim()) {
+                return false;
+            }
+
+            await execa('git', ['merge-base', '--is-ancestor', commitHash, `${upstream.trim()}`]);
+            return true;
+        } catch {
+            return false;
         }
     }
 }

--- a/src/utils/vcs.ts
+++ b/src/utils/vcs.ts
@@ -312,3 +312,27 @@ export const getRecentCommits = async (count: number = 5): Promise<string> => {
     const adapter = await getVCSAdapter();
     return adapter.getRecentCommits(count);
 };
+
+export const rewriteCommit = async (message: string, commitHash: string = 'HEAD'): Promise<void> => {
+    const adapter = await getVCSAdapter();
+    if (!adapter.rewriteCommit) {
+        throw new KnownError(`Rewrite is not supported for ${adapter.name} repositories. Only Git is supported.`);
+    }
+    await adapter.rewriteCommit(message, commitHash);
+};
+
+export const getCommitMessage = async (commitHash: string = 'HEAD'): Promise<string> => {
+    const adapter = await getVCSAdapter();
+    if (!adapter.getCommitMessage) {
+        return '';
+    }
+    return adapter.getCommitMessage(commitHash);
+};
+
+export const isCommitPushed = async (commitHash: string = 'HEAD'): Promise<boolean> => {
+    const adapter = await getVCSAdapter();
+    if (!adapter.isCommitPushed) {
+        return false;
+    }
+    return adapter.isCommitPushed(commitHash);
+};

--- a/tests/specs/cli/index.ts
+++ b/tests/specs/cli/index.ts
@@ -4,5 +4,6 @@ export default testSuite(({ describe }) => {
     describe('CLI', ({ runTestSuite }) => {
         runTestSuite(import('./error-cases.js'));
         runTestSuite(import('./commits.js'));
+        runTestSuite(import('./rewrite.js'));
     });
 });

--- a/tests/specs/cli/rewrite.ts
+++ b/tests/specs/cli/rewrite.ts
@@ -1,0 +1,232 @@
+import { expect, testSuite } from 'manten';
+
+import { createFixture, createGit } from '../../utils.js';
+
+export default testSuite(({ describe }) => {
+    describe('rewrite command', ({ test }) => {
+        // ─── Repository detection ───────────────────────────────
+
+        test('Fails on non-Git project', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const { stdout, exitCode } = await aicommit2(['rewrite'], { reject: false });
+            expect(exitCode).toBe(1);
+            expect(stdout).toMatch('No supported VCS repository found');
+            await fixture.rm();
+        });
+
+        test('Fails in empty git repo without commits', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            await createGit(fixture.path);
+
+            const { stdout, exitCode } = await aicommit2(['rewrite'], { reject: false });
+            expect(exitCode).toBe(1);
+            // Error may come from git directly or from VCS layer
+            expect(stdout).toMatch(/Could not retrieve|Command failed|No supported VCS|No staged changes|fatal/);
+            await fixture.rm();
+        });
+
+        // ─── Commit hash validation ─────────────────────────────
+
+        test('Fails on invalid commit hash', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            await createGit(fixture.path);
+
+            const { stdout, exitCode } = await aicommit2(['rewrite', 'deadbeef'], { reject: false });
+            expect(exitCode).toBe(1);
+            expect(stdout).toMatch('Invalid commit reference');
+            await fixture.rm();
+        });
+
+        test('Fails on non-existent commit when repo has commits', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const git = await createGit(fixture.path);
+            await git('commit', ['--allow-empty', '-m', 'initial commit']);
+
+            const { stdout, exitCode } = await aicommit2(['rewrite', 'nonexistent'], { reject: false });
+            expect(exitCode).toBe(1);
+            expect(stdout).toMatch('Invalid commit reference');
+            await fixture.rm();
+        });
+
+        test('Fails on branch name without commits', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            await createGit(fixture.path);
+
+            // Use a branch name that doesn't exist as a commit reference
+            const { stdout, exitCode } = await aicommit2(['rewrite', 'main'], { reject: false });
+            expect(exitCode).toBe(1);
+            expect(stdout).toMatch('Invalid commit reference');
+            await fixture.rm();
+        });
+
+        test('Accepts HEAD reference by default (no arg)', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const git = await createGit(fixture.path);
+            await git('commit', ['--allow-empty', '-m', 'test']);
+
+            // Running without hash should not fail on "Invalid commit reference"
+            const { stdout, exitCode } = await aicommit2(['rewrite'], { reject: false });
+            expect(exitCode).toBe(1);
+            expect(stdout).not.toMatch('Invalid commit reference');
+            await fixture.rm();
+        });
+
+        test('Accepts full commit hash', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const git = await createGit(fixture.path);
+            await git('commit', ['--allow-empty', '-m', 'commit 1']);
+
+            // Get the actual commit hash
+            const { stdout: hashOut } = await git('rev-parse', ['HEAD']);
+            const fullHash = hashOut.trim();
+
+            // Should be accepted as valid (will fail on missing AI key, not invalid hash)
+            const { stdout } = await aicommit2(['rewrite', fullHash], { reject: false });
+            expect(stdout).not.toMatch('Invalid commit reference');
+            await fixture.rm();
+        });
+
+        test('Accepts short commit hash', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const git = await createGit(fixture.path);
+            await git('commit', ['--allow-empty', '-m', 'commit 1']);
+
+            const { stdout: hashOut } = await git('rev-parse', ['--short', 'HEAD']);
+            const shortHash = hashOut.trim();
+
+            const { stdout } = await aicommit2(['rewrite', shortHash], { reject: false });
+            expect(stdout).not.toMatch('Invalid commit reference');
+            await fixture.rm();
+        });
+
+        test('Accepts HEAD~N style references', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const git = await createGit(fixture.path);
+            await git('commit', ['--allow-empty', '-m', 'commit 1']);
+            await git('commit', ['--allow-empty', '-m', 'commit 2']);
+
+            // HEAD~1 should be valid (refers to first parent)
+            const { stdout } = await aicommit2(['rewrite', 'HEAD~1', '--help']);
+            expect(stdout).toMatch('aicommit2 rewrite');
+            await fixture.rm();
+        });
+
+        test('Accepts HEAD^ parent reference', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const git = await createGit(fixture.path);
+            await git('commit', ['--allow-empty', '-m', 'commit 1']);
+            await git('commit', ['--allow-empty', '-m', 'commit 2']);
+
+            const { stdout } = await aicommit2(['rewrite', 'HEAD^'], { reject: false });
+            expect(stdout).not.toMatch('Invalid commit reference');
+            await fixture.rm();
+        });
+
+        // ─── Help text ──────────────────────────────────────────
+
+        test('Shows help text with correct command name', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const { stdout } = await aicommit2(['rewrite', '--help']);
+            expect(stdout).toMatch('aicommit2 rewrite');
+            expect(stdout).toMatch('Rewrite the commit message');
+            // Should NOT contain old name
+            expect(stdout).not.toMatch(/\bamend\b/);
+            await fixture.rm();
+        });
+
+        test('Shows in main help output', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const { stdout } = await aicommit2(['--help']);
+            expect(stdout).toMatch('rewrite');
+            expect(stdout).toMatch('Rewrite the commit message');
+            await fixture.rm();
+        });
+
+        test('Help shows all supported flags', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const { stdout } = await aicommit2(['rewrite', '--help']);
+
+            // Verify key flags are documented
+            expect(stdout).toMatch('--generate');
+            expect(stdout).toMatch('--dry-run');
+            expect(stdout).toMatch('--confirm');
+            expect(stdout).toMatch('--auto-select');
+            expect(stdout).toMatch('--edit');
+            expect(stdout).toMatch('--locale');
+            expect(stdout).toMatch('--type');
+            expect(stdout).toMatch('--prompt');
+            expect(stdout).toMatch('--verbose');
+            expect(stdout).toMatch('--disable-lowercase');
+            await fixture.rm();
+        });
+
+        test('Help shows usage examples', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const { stdout } = await aicommit2(['rewrite', '--help']);
+
+            expect(stdout).toMatch('aicommit2 rewrite');
+            expect(stdout).toMatch('aicommit2 rewrite -g 3');
+            expect(stdout).toMatch('aicommit2 rewrite abc1234');
+            expect(stdout).toMatch('aicommit2 rewrite HEAD~2 --dry-run');
+            await fixture.rm();
+        });
+
+        // ─── Flag combinations ──────────────────────────────────
+
+        test('Accepts --dry-run with valid repo', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            await createGit(fixture.path);
+
+            const { stdout, exitCode } = await aicommit2(['rewrite', '--dry-run'], { reject: false });
+            expect(exitCode).toBe(1);
+            // Should not be a flag parsing error
+            expect(stdout).not.toMatch('Unknown flag');
+            await fixture.rm();
+        });
+
+        test('Accepts -g flag with numeric value', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            await createGit(fixture.path);
+
+            const { stdout } = await aicommit2(['rewrite', '-g', '3', '--help']);
+            expect(stdout).toMatch('aicommit2 rewrite');
+            await fixture.rm();
+        });
+
+        test('Accepts combined short flags', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            await createGit(fixture.path);
+
+            const { stdout } = await aicommit2(['rewrite', '-d', '-v', '--help']);
+            expect(stdout).toMatch('aicommit2 rewrite');
+            await fixture.rm();
+        });
+
+        test('Accepts --type=conventional syntax', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            await createGit(fixture.path);
+
+            const { stdout } = await aicommit2(['rewrite', '--type=conventional', '--help']);
+            expect(stdout).toMatch('aicommit2 rewrite');
+            await fixture.rm();
+        });
+
+        test('Accepts -l for locale', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            await createGit(fixture.path);
+
+            const { stdout } = await aicommit2(['rewrite', '-l', 'zh', '--help']);
+            expect(stdout).toMatch('aicommit2 rewrite');
+            await fixture.rm();
+        });
+
+        test('Accepts --prompt with custom text', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            await createGit(fixture.path);
+
+            const { stdout } = await aicommit2(['rewrite', '-p', 'use conventional commits', '--help']);
+            expect(stdout).toMatch('aicommit2 rewrite');
+            await fixture.rm();
+        });
+    });
+});

--- a/tests/specs/vcs/git-adapter.ts
+++ b/tests/specs/vcs/git-adapter.ts
@@ -3,10 +3,26 @@ import { describe, expect } from 'manten';
 import { GitAdapter } from '../../../src/utils/vcs-adapters/git.adapter.js';
 
 describe('Git Adapter', ({ test: runTest }) => {
+    // ─── Basic adapter properties ──────────────────────────────
+
     runTest('should have correct name', () => {
         const adapter = new GitAdapter();
         expect(adapter.name).toBe('git');
     });
+
+    runTest('should conform to BaseVCSAdapter interface', () => {
+        const adapter = new GitAdapter();
+
+        // All required methods from BaseVCSAdapter
+        expect(typeof adapter.assertRepo).toBe('function');
+        expect(typeof adapter.getStagedDiff).toBe('function');
+        expect(typeof adapter.commit).toBe('function');
+        expect(typeof adapter.getCommentChar).toBe('function');
+        expect(typeof adapter.getBranchName).toBe('function');
+        expect(typeof adapter.getRecentCommits).toBe('function');
+    });
+
+    // ─── Method existence checks ───────────────────────────────
 
     runTest('should handle repository assertion', async () => {
         const adapter = new GitAdapter();
@@ -81,6 +97,125 @@ describe('Git Adapter', ({ test: runTest }) => {
         // Test that binary files are detected and handled in diff output
         // This would involve mocking git diff --numstat and verifying
         // that binary files are properly annotated in the result
-        expect(true).toBe(true); // Placeholder
+        expect(true).toBe(true); // Placeholder — requires git mock
+    });
+
+    // ─── rewriteCommit ─────────────────────────────────────────
+
+    runTest('should have rewriteCommit method', () => {
+        const adapter = new GitAdapter();
+        expect(typeof adapter.rewriteCommit).toBe('function');
+    });
+
+    runTest('rewriteCommit should accept message string', () => {
+        const adapter = new GitAdapter();
+        // Function signature: (message: string, commitHash?: string) => Promise<void>
+        expect(adapter.rewriteCommit?.length).toBeGreaterThanOrEqual(1);
+    });
+
+    runTest('rewriteCommit default commitHash should be HEAD', async () => {
+        const adapter = new GitAdapter();
+        // When called with only message, commitHash defaults to 'HEAD'
+        // This is verified by checking the function parameter default
+        const fnStr = adapter.rewriteCommit?.toString() || '';
+        expect(fnStr).toMatch(/commitHash.*=.*['"]HEAD['"]/);
+    });
+
+    // ─── getCommitMessage ──────────────────────────────────────
+
+    runTest('should have getCommitMessage method', () => {
+        const adapter = new GitAdapter();
+        expect(typeof adapter.getCommitMessage).toBe('function');
+    });
+
+    runTest('getCommitMessage should accept optional commitHash', () => {
+        const adapter = new GitAdapter();
+        expect(adapter.getCommitMessage?.length).toBeGreaterThanOrEqual(0);
+    });
+
+    runTest('getCommitMessage default commitHash should be HEAD', async () => {
+        const adapter = new GitAdapter();
+        const fnStr = adapter.getCommitMessage?.toString() || '';
+        expect(fnStr).toMatch(/commitHash.*=.*['"]HEAD['"]/);
+    });
+
+    runTest('getCommitMessage returns empty string on error', () => {
+        // Method wraps git log and returns '' on any error
+        const adapter = new GitAdapter();
+        // Test the signature — actual mock test would verify catch path
+        expect(adapter.getCommitMessage).toBeDefined();
+    });
+
+    // ─── isCommitPushed ────────────────────────────────────────
+
+    runTest('should have isCommitPushed method', () => {
+        const adapter = new GitAdapter();
+        expect(typeof adapter.isCommitPushed).toBe('function');
+    });
+
+    runTest('isCommitPushed should accept optional commitHash', () => {
+        const adapter = new GitAdapter();
+        expect(adapter.isCommitPushed?.length).toBeGreaterThanOrEqual(0);
+    });
+
+    runTest('isCommitPushed default commitHash should be HEAD', async () => {
+        const adapter = new GitAdapter();
+        const fnStr = adapter.isCommitPushed?.toString() || '';
+        expect(fnStr).toMatch(/commitHash.*=.*['"]HEAD['"]/);
+    });
+
+    runTest('isCommitPushed returns false when upstream not configured', () => {
+        // Method returns false when git rev-parse @{u} fails
+        const adapter = new GitAdapter();
+        expect(adapter.isCommitPushed).toBeDefined();
+    });
+
+    // ─── rewriteCommit via vcs.ts layer ────────────────────────
+
+    runTest('should handle rewrite from vcs.ts layer', async () => {
+        const { rewriteCommit } = await import('../../../src/utils/vcs.js');
+        expect(typeof rewriteCommit).toBe('function');
+    });
+
+    runTest('vcs.ts rewriteCommit accepts message and optional commitHash', async () => {
+        const { rewriteCommit } = await import('../../../src/utils/vcs.js');
+        // (message: string, commitHash?: string) => Promise<void>
+        expect(rewriteCommit.length).toBeGreaterThanOrEqual(1);
+    });
+
+    runTest('vcs.ts getCommitMessage is exported', async () => {
+        const { getCommitMessage } = await import('../../../src/utils/vcs.js');
+        expect(typeof getCommitMessage).toBe('function');
+    });
+
+    runTest('vcs.ts isCommitPushed is exported', async () => {
+        const { isCommitPushed } = await import('../../../src/utils/vcs.js');
+        expect(typeof isCommitPushed).toBe('function');
+    });
+
+    // ─── Branch name edge cases ────────────────────────────────
+
+    runTest('getBranchName returns string', () => {
+        const adapter = new GitAdapter();
+        expect(typeof adapter.getBranchName).toBe('function');
+    });
+
+    runTest('getRecentCommits returns string', () => {
+        const adapter = new GitAdapter();
+        expect(typeof adapter.getRecentCommits).toBe('function');
+    });
+
+    // ─── Commit diff with arguments ────────────────────────────
+
+    runTest('getCommitDiff accepts excludeFiles and exclude arrays', () => {
+        const adapter = new GitAdapter();
+        // (commitHash, excludeFiles?, exclude?, options?) => Promise<VCSDiff | null>
+        expect(adapter.getCommitDiff?.length).toBeGreaterThanOrEqual(1);
+    });
+
+    runTest('getStagedDiff accepts excludeFiles and exclude arrays', () => {
+        const adapter = new GitAdapter();
+        // (excludeFiles?, exclude?, options?) => Promise<VCSDiff | null>
+        expect(adapter.getStagedDiff.length).toBeGreaterThanOrEqual(0);
     });
 });


### PR DESCRIPTION
### Issue

N/A

### Description

Adds `aicommit2 rewrite`, a new command for rewriting an existing Git commit message with AI.

This PR includes:

- A new `rewrite` CLI command, defaulting to `HEAD` and supporting explicit commit refs such as commit hashes or `HEAD~2`
- AI-generated replacement commit messages using the existing provider/config flow
- Support for `--dry-run`, `--edit`, `--confirm`, `--auto-select`, `--generate`, `--locale`, `--type`, `--prompt`, and `--disable-lowercase`
- Git adapter support for reading commit diffs/messages, checking whether a commit has been pushed, and rewriting commit messages
- Documentation and README updates for the new command
- CLI and VCS adapter tests covering command registration, help output, commit reference validation, and exported rewrite helpers

This feature currently supports Git only. Jujutsu and YADM are not adapted for commit message rewrite in this PR.


https://github.com/user-attachments/assets/872d7d2c-9af0-412b-a55d-134ac8539070



### Testing

- `pnpm test`
- `pnpm lint`
- `pnpm type-check`

### Additional context

For non-HEAD commits, rewriting is implemented through Git rebase, so the target commit and its descendants may receive new commit hashes. If the commit has already been pushed, users should review the warning carefully before continuing.