### PR TITLE
fix: require explicit opt-in for Copilot SDK provider

### DIFF
--- a/src/commands/get-available-ais.ts
+++ b/src/commands/get-available-ais.ts
@@ -24,7 +24,11 @@ const isCopilotSdkInstalled = (): boolean => {
 let copilotSdkInstalled: boolean | undefined;
 
 const hasCopilotSdkAvailable = (value: RawConfig): boolean => {
-    if (!hasConfiguredModels(value)) {
+    // COPILOT_SDK must be opted into explicitly; the SDK package is a bundled
+    // dependency, so its presence alone is not a signal of user intent (issue #254).
+    const hasOptInSignal =
+        hasConfiguredModels(value) || isNonEmptyString(value.key as string) || isNonEmptyString(process.env.COPILOT_GITHUB_TOKEN);
+    if (!hasOptInSignal) {
         return false;
     }
     if (copilotSdkInstalled === undefined) {
@@ -97,7 +101,7 @@ export const getAvailableAIs = (config: ValidConfig, requestType: RequestType): 
                         return !!value && hasConfiguredModels(value) && codeReview;
                     }
                     if (key === 'COPILOT_SDK') {
-                        return !!value && hasConfiguredModels(value) && codeReview;
+                        return !!value && hasCopilotSdkAvailable(value) && codeReview;
                     }
                     if (key === 'HUGGINGFACE') {
                         return !!value && !!value.cookie && codeReview;
@@ -112,7 +116,7 @@ export const getAvailableAIs = (config: ValidConfig, requestType: RequestType): 
                         return !!value && hasConfiguredModels(value) && watchMode;
                     }
                     if (key === 'COPILOT_SDK') {
-                        return !!value && hasConfiguredModels(value) && watchMode;
+                        return !!value && hasCopilotSdkAvailable(value) && watchMode;
                     }
                     if (key === 'HUGGINGFACE') {
                         return !!value && !!value.cookie && watchMode;

--- a/src/services/ai/copilot-sdk.service.ts
+++ b/src/services/ai/copilot-sdk.service.ts
@@ -192,7 +192,11 @@ export class CopilotSdkService extends AIService {
                 }
             } finally {
                 if (client?.stop) {
-                    await client.stop();
+                    try {
+                        await client.stop();
+                    } catch {
+                        // Ignore stop failures so they don't mask the in-flight error.
+                    }
                 }
             }
         }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -914,7 +914,10 @@ const modelConfigParsers: Record<ModelName, Record<string, (value: any) => any>>
         envKey: (envKey?: string) => envKey || '',
         model: (model?: string | string[]): string[] => {
             if (!model) {
-                return ['gpt-4.1'];
+                // No implicit default: an explicitly configured model is the opt-in
+                // signal that activates the Copilot SDK provider (issue #254).
+                // The service falls back to COPILOT_SDK_DEFAULT_MODEL at request time.
+                return [];
             }
             const modelList = typeof model === 'string' ? model?.split(',') : model;
             return modelList.map(m => m.trim()).filter(m => !!m && m.length > 0);

--- a/tests/specs/config.ts
+++ b/tests/specs/config.ts
@@ -338,6 +338,61 @@ export default testSuite(({ describe }) => {
             });
         });
 
+        await describe('Copilot SDK configuration', async ({ test }) => {
+            const envKeys = ['AICOMMIT_CONFIG_PATH', 'COPILOT_GITHUB_TOKEN', 'COPILOT_SDK_API_KEY'];
+
+            await test('COPILOT_SDK defaults to no model and stays inactive without opt-in', async () => {
+                const { fixture } = await createFixture();
+                const configPath = path.join(fixture.path, '.config', 'aicommit2', 'config.ini');
+                await ensureDirectoryExists(path.dirname(configPath));
+                await fs.writeFile(configPath, ['[OPENAI]', 'key=sk-test', ''].join('\n'));
+
+                const snapshot = snapshotEnv(envKeys);
+
+                process.env.AICOMMIT_CONFIG_PATH = configPath;
+                delete process.env.COPILOT_GITHUB_TOKEN;
+                delete process.env.COPILOT_SDK_API_KEY;
+
+                const config = (await getConfig({}, [])) as ValidConfig;
+                const copilotSdk = config.COPILOT_SDK as any;
+
+                expect(copilotSdk.model).toEqual([]);
+
+                const commitAIs = getAvailableAIs(config, 'commit');
+
+                expect(commitAIs).toContain('OPENAI');
+                expect(commitAIs).not.toContain('COPILOT_SDK');
+
+                await fixture.rm();
+                restoreEnv(snapshot);
+            });
+
+            await test('COPILOT_SDK activates with an explicitly configured model', async () => {
+                const { fixture } = await createFixture();
+                const configPath = path.join(fixture.path, '.config', 'aicommit2', 'config.ini');
+                await ensureDirectoryExists(path.dirname(configPath));
+                await fs.writeFile(configPath, ['[COPILOT_SDK]', 'model=gpt-4.1', ''].join('\n'));
+
+                const snapshot = snapshotEnv(envKeys);
+
+                process.env.AICOMMIT_CONFIG_PATH = configPath;
+                delete process.env.COPILOT_GITHUB_TOKEN;
+                delete process.env.COPILOT_SDK_API_KEY;
+
+                const config = (await getConfig({}, [])) as ValidConfig;
+                const copilotSdk = config.COPILOT_SDK as any;
+
+                expect(copilotSdk.model).toEqual(['gpt-4.1']);
+
+                const commitAIs = getAvailableAIs(config, 'commit');
+
+                expect(commitAIs).toContain('COPILOT_SDK');
+
+                await fixture.rm();
+                restoreEnv(snapshot);
+            });
+        });
+
         await describe('Bedrock configuration', async ({ test }) => {
             const envKeys = [
                 'AICOMMIT_CONFIG_PATH',

--- a/tests/specs/copilot-sdk/utils.ts
+++ b/tests/specs/copilot-sdk/utils.ts
@@ -84,5 +84,74 @@ export default testSuite(({ describe }) => {
             expect(reviewAIs).toContain('COPILOT_SDK');
             expect(watchAIs).toContain('COPILOT_SDK');
         });
+
+        const withCopilotToken = (token: string | undefined, run: () => void) => {
+            const originalToken = process.env.COPILOT_GITHUB_TOKEN;
+            if (token === undefined) {
+                delete process.env.COPILOT_GITHUB_TOKEN;
+            } else {
+                process.env.COPILOT_GITHUB_TOKEN = token;
+            }
+            try {
+                run();
+            } finally {
+                if (originalToken === undefined) {
+                    delete process.env.COPILOT_GITHUB_TOKEN;
+                } else {
+                    process.env.COPILOT_GITHUB_TOKEN = originalToken;
+                }
+            }
+        };
+
+        test('COPILOT_SDK is not available without an explicit opt-in signal', () => {
+            withCopilotToken(undefined, () => {
+                const config = {
+                    codeReview: true,
+                    watchMode: true,
+                    COPILOT_SDK: {
+                        model: [],
+                        key: '',
+                    },
+                } as any;
+
+                const commitAIs = getAvailableAIs(config, 'commit');
+                const reviewAIs = getAvailableAIs(config, 'review');
+                const watchAIs = getAvailableAIs(config, 'watch');
+
+                expect(commitAIs).not.toContain('COPILOT_SDK');
+                expect(reviewAIs).not.toContain('COPILOT_SDK');
+                expect(watchAIs).not.toContain('COPILOT_SDK');
+            });
+        });
+
+        test('COPILOT_SDK is available when COPILOT_GITHUB_TOKEN is set', () => {
+            withCopilotToken('github_pat_test', () => {
+                const config = {
+                    COPILOT_SDK: {
+                        model: [],
+                        key: '',
+                    },
+                } as any;
+
+                const commitAIs = getAvailableAIs(config, 'commit');
+
+                expect(commitAIs).toContain('COPILOT_SDK');
+            });
+        });
+
+        test('COPILOT_SDK is available when key is configured', () => {
+            withCopilotToken(undefined, () => {
+                const config = {
+                    COPILOT_SDK: {
+                        model: [],
+                        key: 'github_pat_test',
+                    },
+                } as any;
+
+                const commitAIs = getAvailableAIs(config, 'commit');
+
+                expect(commitAIs).toContain('COPILOT_SDK');
+            });
+        });
     });
 });


### PR DESCRIPTION
The bundled @github/copilot-sdk dependency plus an implicit gpt-4.1 model default caused COPILOT_SDK to auto-activate for every user. Without Copilot CLI auth it failed with a misattributed unhandled rejection: "Session was not created with authentication info".

- COPILOT_SDK model parser no longer defaults to gpt-4.1; the service still falls back to COPILOT_SDK_DEFAULT_MODEL at request time
- availability now requires an opt-in signal: configured model, key, or COPILOT_GITHUB_TOKEN
- client.stop() failures no longer mask the in-flight error

Fixes #254

### Issue

Issue number, if available, prefixed with "#"

### Description

What does this implement/fix? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

______________________________________________________________________

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
