### PR TITLE
Fix/issues 262 263

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,9 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-        args: [-Loll]
+        # `modell` is a deliberate misspelling: README documents it as the typo
+        # `config validate` suggests a correction for
+        args: ['-Loll,modell']
         exclude: ^(flake\.nix|src/utils/prompt\.ts|pnpm-lock\.yaml|tests/eval/golden/.*)$
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1

--- a/README.md
+++ b/README.md
@@ -406,7 +406,8 @@ Run `aicommit2 --help` to see all available options grouped by category.
 
 - `--all` or `-a`: Automatically stage changes in tracked files for the commit (default: **false**)
 - `--confirm` or `-y`: Skip confirmation when committing after message generation (default: **false**)
-- `--auto-select` or `-s`: Automatically select when only one message is generated (default: **false**)
+- `--auto-select` or `-s`: Automatically select the first successfully generated message (default: **false**)
+  - Runs non-interactively: skips both the message picker and the commit confirmation, regardless of how many AI providers are configured
 - `--edit` or `-e`: Open the AI-generated commit message in your default editor (default: **false**)
 - `--clipboard` or `-c`: Copy the selected message to clipboard and exit **without committing** (default: **false**)
 - `--dry-run` or `-d`: Generate commit message without committing (default: **false**)

--- a/README.md
+++ b/README.md
@@ -836,6 +836,7 @@ directly in `config.ini` using dotted keys, or set with JSON via `aicommit2 conf
 - READ: `aicommit2 config get [<key> [<key> ...]]`
 - SET: `aicommit2 config set <key>=<value>`
 - DELETE: `aicommit2 config del <config-name>`
+- VALIDATE: `aicommit2 config validate`
 
 Example:
 
@@ -854,6 +855,27 @@ aicommit2 config set OPENAI.generate=3 GEMINI.temperature=0.5
 aicommit2 config del OPENAI.key
 aicommit2 config del GEMINI
 aicommit2 config del timeout
+
+# Check the configuration file
+aicommit2 config validate
+```
+
+#### Validating the Configuration
+
+A hand-edited `config.ini` can contain mistakes that a normal run stays silent about: a
+section whose name is not uppercase is dropped entirely, and an option no provider
+accepts is ignored. `aicommit2 config validate` reports them together with any invalid
+values, and exits with a non-zero status when it finds an error. Values are checked after
+environment variable expansion, so run it in the same environment your commits run in:
+
+```
+Config file: ~/.config/aicommit2/config.ini
+
+✖ [openai]: Invalid section name, so the whole section is ignored. Names must be uppercase letters, numbers and underscores. Did you mean [OPENAI]?
+! OPENAI.modell: Unknown option, silently ignored. Did you mean `model`?
+✖ OPENAI.temperature: Invalid config property temperature: Must be decimal between 0 and 2
+
+2 error(s), 1 warning(s)
 ```
 
 ### Environment Variables

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,9 @@ import rewriteCommand from './commands/rewrite.js';
 import setupCommand from './commands/setup.js';
 import { statsCommand } from './commands/stats.js';
 import { watchGit } from './commands/watch-git.js';
-import { RawConfig, getConfig } from './utils/config.js';
+import { ConsoleManager } from './managers/console.manager.js';
+import { RawConfig, ValidConfig, getConfig } from './utils/config.js';
+import { handleCliError } from './utils/error.js';
 import { renderGroupedHelp } from './utils/help-renderer.js';
 import { initializeLogger, logger } from './utils/logger.js';
 
@@ -170,7 +172,20 @@ cli(
             cliOverrides.logLevel = 'verbose';
         }
 
-        const config = await getConfig(cliOverrides, rawArgv);
+        // Nothing above catches here, so an unreadable or invalid config file would surface
+        // as a raw unhandled rejection instead of the message it carries.
+        let config: ValidConfig;
+        try {
+            config = await getConfig(cliOverrides, rawArgv);
+        } catch (error) {
+            const consoleManager = new ConsoleManager();
+            consoleManager.printError((error as Error).message);
+            // Parsing stops at the first bad value, so point at the command that reports all of them
+            consoleManager.printInfo('Run `aicommit2 config validate` to check the whole configuration file.');
+            handleCliError(error);
+            process.exit(1);
+        }
+
         await initializeLogger(config);
         logger.info(`aicommit2 version: ${version}`);
         if (argv.flags['pre-commit']) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,7 +101,7 @@ cli(
             },
             'auto-select': {
                 type: Boolean,
-                description: 'Automatically select the message when only one is generated',
+                description: 'Automatically select the first successfully generated message (skips the picker and the commit confirmation)',
                 alias: 's',
                 default: false,
             },

--- a/src/commands/aicommit2.ts
+++ b/src/commands/aicommit2.ts
@@ -338,6 +338,79 @@ async function handleCodeReview(aiRequestManager: AIRequestManager, availableAIs
     }
 }
 
+/**
+ * Pick a message without mounting the interactive prompt. Resolves on the first usable
+ * message rather than waiting for every provider — with several configured, waiting for
+ * the slowest would make --auto-select slower than picking from the list by hand.
+ */
+const selectMessageAutomatically = async (
+    aiRequestManager: AIRequestManager,
+    availableAIs: ModelName[],
+    commitMsgPromptManager: ReactivePromptManager
+): Promise<CommitMessageResult> => {
+    const messages: CommitChoice[] = [];
+    // The promise executor runs synchronously, so this is assigned before subscribing below
+    let resolveSelection!: (message: CommitChoice | null) => void;
+    const selection = new Promise<CommitChoice | null>(resolve => {
+        resolveSelection = resolve;
+    });
+
+    // No prompt is mounted here, so the console bar is the only feedback during the wait
+    consoleManager.showLoader(commitMsgLoader.startOption.text, barSpinner);
+
+    const commitMsgSubscription = aiRequestManager.createCommitMsgRequests$(availableAIs).subscribe({
+        next: (choice: ReactiveListChoice) => {
+            commitMsgPromptManager.refreshChoices(choice);
+            // Skip streaming preview/sentinel choices — only collect final results
+            const isStreamingChoice = 'streamKey' in choice;
+            if (isStreamingChoice) {
+                return;
+            }
+            const commitChoice = choice as CommitChoice;
+            messages.push(commitChoice);
+            if (commitChoice.value && !commitChoice.isError && !commitChoice.disabled) {
+                resolveSelection(commitChoice);
+            }
+        },
+        error: error => {
+            console.error('Commit message generation error:', error);
+            commitMsgPromptManager.checkErrorOnChoices(false);
+            resolveSelection(null);
+        },
+        complete: () => {
+            commitMsgPromptManager.checkErrorOnChoices(false);
+            resolveSelection(null);
+        },
+    });
+
+    try {
+        const selectedMessage = await selection;
+
+        consoleManager.stopLoader();
+
+        if (!selectedMessage || !selectedMessage.value) {
+            // No prompt was mounted, so nothing has rendered the per-model error lines.
+            // Print them before failing — otherwise the run ends with no explanation.
+            messages.forEach(msg => {
+                if (msg.isError && msg.name) {
+                    consoleManager.print(msg.name);
+                }
+            });
+            throw new KnownError('No valid commit message was generated');
+        }
+
+        consoleManager.print(`\n${selectedMessage.name}\n`);
+        return {
+            value: selectedMessage.value,
+            provider: selectedMessage.provider || 'unknown',
+            model: selectedMessage.model || 'unknown',
+        };
+    } finally {
+        // Aborts the requests still in flight behind the one that answered first
+        commitMsgSubscription.unsubscribe();
+    }
+};
+
 const handleCommitMessage = async (
     aiRequestManager: AIRequestManager,
     availableAIs: ModelName[],
@@ -348,62 +421,7 @@ const handleCommitMessage = async (
 
     try {
         if (autoSelect) {
-            const messages: CommitChoice[] = [];
-            // No interactive prompt is mounted in auto-select mode — the console bar is the
-            // only feedback during this wait, so it runs the whole generation here.
-            consoleManager.showLoader(commitMsgLoader.startOption.text, barSpinner);
-
-            const selectedMessage = await new Promise<CommitChoice | null>(resolve => {
-                const subscription = aiRequestManager.createCommitMsgRequests$(availableAIs).subscribe({
-                    next: (choice: ReactiveListChoice) => {
-                        commitMsgPromptManager.refreshChoices(choice);
-                        // Skip streaming preview/sentinel choices — only collect final results
-                        const isStreamingChoice = 'streamKey' in choice;
-                        if (isStreamingChoice) {
-                            return;
-                        }
-                        const commitChoice = choice as CommitChoice;
-                        messages.push(commitChoice);
-                        // Resolve on the first usable message rather than waiting for every
-                        // provider — with several configured, waiting for the slowest would
-                        // make --auto-select slower than picking from the list by hand.
-                        // The subscription is torn down in `finally`, aborting in-flight requests.
-                        if (commitChoice.value && !commitChoice.isError && !commitChoice.disabled) {
-                            resolve(commitChoice);
-                        }
-                    },
-                    error: error => {
-                        console.error('Commit message generation error:', error);
-                        commitMsgPromptManager.checkErrorOnChoices(false);
-                        resolve(null);
-                    },
-                    complete: () => {
-                        commitMsgPromptManager.checkErrorOnChoices(false);
-                        resolve(null);
-                    },
-                });
-                commitMsgSubscription = subscription;
-            });
-
-            consoleManager.stopLoader();
-
-            if (!selectedMessage || !selectedMessage.value) {
-                // No prompt was mounted, so nothing has rendered the per-model error lines.
-                // Print them before failing — otherwise the run ends with no explanation.
-                messages.forEach(msg => {
-                    if (msg.isError && msg.name) {
-                        consoleManager.print(msg.name);
-                    }
-                });
-                throw new KnownError('No valid commit message was generated');
-            }
-
-            consoleManager.print(`\n${selectedMessage.name}\n`);
-            return {
-                value: selectedMessage.value,
-                provider: selectedMessage.provider || 'unknown',
-                model: selectedMessage.model || 'unknown',
-            };
+            return await selectMessageAutomatically(aiRequestManager, availableAIs, commitMsgPromptManager);
         }
 
         // Store choices with metadata for later lookup

--- a/src/commands/aicommit2.ts
+++ b/src/commands/aicommit2.ts
@@ -243,7 +243,7 @@ export default async (
             process.exit();
         }
 
-        if (confirm || (autoSelect && availableAIs.length === 1)) {
+        if (confirm || autoSelect) {
             await commitChanges(selectedCommitMessage, rawArgv, commitOptions);
             process.exit();
         }
@@ -347,44 +347,62 @@ const handleCommitMessage = async (
     let commitMsgSubscription: Subscription | null = null;
 
     try {
-        if (autoSelect && availableAIs.length === 1) {
+        if (autoSelect) {
             const messages: CommitChoice[] = [];
-            // Single AI, no interactive prompt to mount — the console bar is the only
-            // feedback during this wait, so it runs the whole generation here.
+            // No interactive prompt is mounted in auto-select mode — the console bar is the
+            // only feedback during this wait, so it runs the whole generation here.
             consoleManager.showLoader(commitMsgLoader.startOption.text, barSpinner);
 
-            commitMsgSubscription = aiRequestManager.createCommitMsgRequests$(availableAIs).subscribe({
-                next: (choice: ReactiveListChoice) => {
-                    // Skip streaming preview/sentinel choices — only collect final results
-                    const isStreamingChoice = 'streamKey' in choice;
-                    if (!isStreamingChoice) {
-                        messages.push(choice as CommitChoice);
-                    }
-                    commitMsgPromptManager.refreshChoices(choice);
-                },
-                error: error => {
-                    console.error('Commit message generation error:', error);
-                    commitMsgPromptManager.checkErrorOnChoices(false);
-                },
-                complete: () => commitMsgPromptManager.checkErrorOnChoices(false),
-            });
-
-            await new Promise<void>(resolve => {
-                commitMsgSubscription?.add(() => resolve());
+            const selectedMessage = await new Promise<CommitChoice | null>(resolve => {
+                const subscription = aiRequestManager.createCommitMsgRequests$(availableAIs).subscribe({
+                    next: (choice: ReactiveListChoice) => {
+                        commitMsgPromptManager.refreshChoices(choice);
+                        // Skip streaming preview/sentinel choices — only collect final results
+                        const isStreamingChoice = 'streamKey' in choice;
+                        if (isStreamingChoice) {
+                            return;
+                        }
+                        const commitChoice = choice as CommitChoice;
+                        messages.push(commitChoice);
+                        // Resolve on the first usable message rather than waiting for every
+                        // provider — with several configured, waiting for the slowest would
+                        // make --auto-select slower than picking from the list by hand.
+                        // The subscription is torn down in `finally`, aborting in-flight requests.
+                        if (commitChoice.value && !commitChoice.isError && !commitChoice.disabled) {
+                            resolve(commitChoice);
+                        }
+                    },
+                    error: error => {
+                        console.error('Commit message generation error:', error);
+                        commitMsgPromptManager.checkErrorOnChoices(false);
+                        resolve(null);
+                    },
+                    complete: () => {
+                        commitMsgPromptManager.checkErrorOnChoices(false);
+                        resolve(null);
+                    },
+                });
+                commitMsgSubscription = subscription;
             });
 
             consoleManager.stopLoader();
 
-            const validMessage = messages.find(msg => msg.value && !msg.isError && !msg.disabled);
-            if (!validMessage || !validMessage.value) {
+            if (!selectedMessage || !selectedMessage.value) {
+                // No prompt was mounted, so nothing has rendered the per-model error lines.
+                // Print them before failing — otherwise the run ends with no explanation.
+                messages.forEach(msg => {
+                    if (msg.isError && msg.name) {
+                        consoleManager.print(msg.name);
+                    }
+                });
                 throw new KnownError('No valid commit message was generated');
             }
 
-            consoleManager.print(`\n${validMessage.name}\n`);
+            consoleManager.print(`\n${selectedMessage.name}\n`);
             return {
-                value: validMessage.value,
-                provider: validMessage.provider || 'unknown',
-                model: validMessage.model || 'unknown',
+                value: selectedMessage.value,
+                provider: selectedMessage.provider || 'unknown',
+                model: selectedMessage.model || 'unknown',
             };
         }
 
@@ -392,7 +410,7 @@ const handleCommitMessage = async (
         const choiceMap = new Map<string, CommitChoice>();
         // Progress shown next to the bar as (done/total): final results (including error
         // entries) over the number of AI requests in flight. Streaming previews excluded.
-        const totalRequests = availableAIs.length;
+        const totalRequests = aiRequestManager.countRequests(availableAIs);
         let settledRequests = 0;
 
         // Mount the prompt up front. The library's loading bar hides the question while the

--- a/src/commands/aicommit2.ts
+++ b/src/commands/aicommit2.ts
@@ -9,6 +9,7 @@ import { ReactiveListChoice } from 'inquirer-reactive-list-prompt';
 import { lastValueFrom, toArray } from 'rxjs';
 
 import { getAvailableAIs } from './get-available-ais.js';
+import { CommitChoice, CommitMessageResult, selectMessageAutomatically } from './select-message.js';
 import { AIRequestManager } from '../managers/ai-request.manager.js';
 import { ConsoleManager } from '../managers/console.manager.js';
 import {
@@ -22,7 +23,6 @@ import { recordSelection } from '../services/stats/index.js';
 import { ModelName, RawConfig, applyDisableLowerCaseToConfig, applyIncludeBodyToConfig, getConfig } from '../utils/config.js';
 import { ErrorCode, ErrorMessages } from '../utils/error-messages.js';
 import { KnownError, handleCliError } from '../utils/error.js';
-import { barSpinner } from '../utils/loading-bar.js';
 import { validateSystemPrompt } from '../utils/prompt.js';
 import {
     CommitOptions,
@@ -42,23 +42,6 @@ const consoleManager = new ConsoleManager();
 export interface JsonCommitMessage {
     subject: string;
     body: string;
-}
-
-/**
- * Extended ReactiveListChoice with provider metadata for selection tracking
- */
-interface CommitChoice extends ReactiveListChoice {
-    provider?: string;
-    model?: string;
-}
-
-/**
- * Result of commit message selection
- */
-interface CommitMessageResult {
-    value: string;
-    provider: string;
-    model: string;
 }
 
 export default async (
@@ -337,79 +320,6 @@ async function handleCodeReview(aiRequestManager: AIRequestManager, availableAIs
         codeReviewPromptManager.destroy();
     }
 }
-
-/**
- * Pick a message without mounting the interactive prompt. Resolves on the first usable
- * message rather than waiting for every provider — with several configured, waiting for
- * the slowest would make --auto-select slower than picking from the list by hand.
- */
-const selectMessageAutomatically = async (
-    aiRequestManager: AIRequestManager,
-    availableAIs: ModelName[],
-    commitMsgPromptManager: ReactivePromptManager
-): Promise<CommitMessageResult> => {
-    const messages: CommitChoice[] = [];
-    // The promise executor runs synchronously, so this is assigned before subscribing below
-    let resolveSelection!: (message: CommitChoice | null) => void;
-    const selection = new Promise<CommitChoice | null>(resolve => {
-        resolveSelection = resolve;
-    });
-
-    // No prompt is mounted here, so the console bar is the only feedback during the wait
-    consoleManager.showLoader(commitMsgLoader.startOption.text, barSpinner);
-
-    const commitMsgSubscription = aiRequestManager.createCommitMsgRequests$(availableAIs).subscribe({
-        next: (choice: ReactiveListChoice) => {
-            commitMsgPromptManager.refreshChoices(choice);
-            // Skip streaming preview/sentinel choices — only collect final results
-            const isStreamingChoice = 'streamKey' in choice;
-            if (isStreamingChoice) {
-                return;
-            }
-            const commitChoice = choice as CommitChoice;
-            messages.push(commitChoice);
-            if (commitChoice.value && !commitChoice.isError && !commitChoice.disabled) {
-                resolveSelection(commitChoice);
-            }
-        },
-        error: error => {
-            console.error('Commit message generation error:', error);
-            commitMsgPromptManager.checkErrorOnChoices(false);
-            resolveSelection(null);
-        },
-        complete: () => {
-            commitMsgPromptManager.checkErrorOnChoices(false);
-            resolveSelection(null);
-        },
-    });
-
-    try {
-        const selectedMessage = await selection;
-
-        consoleManager.stopLoader();
-
-        if (!selectedMessage || !selectedMessage.value) {
-            // No prompt was mounted, so nothing has rendered the per-model error lines.
-            // Print them before failing — otherwise the run ends with no explanation.
-            messages.forEach(msg => {
-                if (msg.isError && msg.name) {
-                    consoleManager.print(msg.name);
-                }
-            });
-            throw new KnownError('No valid commit message was generated');
-        }
-
-        consoleManager.print(`\n${selectedMessage.name}\n`);
-        return {
-            value: selectedMessage.value,
-            provider: selectedMessage.provider || 'unknown',
-            model: selectedMessage.model || 'unknown',
-        };
-    } finally {
-        // Aborts the requests still in flight behind the one that answered first
-        commitMsgSubscription.unsubscribe();
-    }
-};
 
 const handleCommitMessage = async (
     aiRequestManager: AIRequestManager,

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,11 +1,44 @@
 import fs from 'fs/promises';
 
+import chalk from 'chalk';
 import { command } from 'cleye';
 import ini from 'ini';
 
 import { ConsoleManager } from '../managers/console.manager.js';
+import { validateConfigFile } from '../utils/config-validator.js';
 import { addConfigs, getConfig, getConfigPath, hasOwn, listConfigs, printConfigPath, readConfigFile, setConfigs } from '../utils/config.js';
 import { KnownError, handleCliError } from '../utils/error.js';
+
+/**
+ * Report the config file findings. Returns true when at least one of them is an error,
+ * so the caller can exit non-zero for scripts and CI.
+ */
+const printConfigValidation = async (): Promise<boolean> => {
+    const { configPath, exists, issues } = await validateConfigFile();
+    const consoleManager = new ConsoleManager();
+
+    console.log(`Config file: ${configPath}\n`);
+
+    if (!exists) {
+        consoleManager.printWarning('No configuration file found. Every setting comes from CLI flags and environment variables.');
+        return false;
+    }
+
+    if (issues.length === 0) {
+        consoleManager.printSuccess('Configuration is valid');
+        return false;
+    }
+
+    for (const issue of issues) {
+        const icon = issue.level === 'error' ? chalk.red.bold('✖') : chalk.yellow.bold('!');
+        const hint = issue.hint ? ` ${chalk.dim(issue.hint)}` : '';
+        console.log(`${icon} ${chalk.bold(issue.location)}: ${issue.message}${hint}`);
+    }
+
+    const errorCount = issues.filter(issue => issue.level === 'error').length;
+    console.log(`\n${errorCount} error(s), ${issues.length - errorCount} warning(s)`);
+    return errorCount > 0;
+};
 
 export default command(
     {
@@ -69,6 +102,14 @@ export default command(
                 help: {
                     description: 'Display the path of the loaded configuration file.',
                     examples: ['aic2 config path'],
+                },
+            }),
+            command({
+                name: 'validate',
+                parameters: [],
+                help: {
+                    description: 'Check the configuration file for ignored sections, unknown options and invalid values.',
+                    examples: ['aic2 config validate'],
                 },
             }),
         ],
@@ -192,6 +233,14 @@ export default command(
 
             if (mode === 'path') {
                 await printConfigPath();
+                return;
+            }
+
+            if (mode === 'validate') {
+                const hasErrors = await printConfigValidation();
+                if (hasErrors) {
+                    process.exit(1);
+                }
                 return;
             }
 

--- a/src/commands/rewrite.ts
+++ b/src/commands/rewrite.ts
@@ -224,7 +224,7 @@ export default command(
                 const choiceMap = new Map<string, RewriteChoice>();
                 // Progress shown next to the bar as (done/total): final results (including
                 // error entries) over the number of AI requests. Streaming previews excluded.
-                const totalRequests = availableAIs.length;
+                const totalRequests = aiRequestManager.countRequests(availableAIs);
                 let settledRequests = 0;
 
                 // Mount up front: the library's loading bar hides the question while the list

--- a/src/commands/rewrite.ts
+++ b/src/commands/rewrite.ts
@@ -9,6 +9,7 @@ import inquirer from 'inquirer';
 import { ReactiveListChoice } from 'inquirer-reactive-list-prompt';
 
 import { getAvailableAIs } from './get-available-ais.js';
+import { selectMessageAutomatically } from './select-message.js';
 import { AIRequestManager } from '../managers/ai-request.manager.js';
 import { ConsoleManager } from '../managers/console.manager.js';
 import { ReactivePromptManager, commitMsgLoader } from '../managers/reactive-prompt.manager.js';
@@ -32,14 +33,6 @@ import {
 import type { Subscription } from 'rxjs';
 
 const consoleManager = new ConsoleManager();
-
-/**
- * Extended ReactiveListChoice with provider metadata for selection tracking
- */
-interface RewriteChoice extends ReactiveListChoice {
-    provider?: string;
-    model?: string;
-}
 
 export default command(
     {
@@ -78,7 +71,7 @@ export default command(
             },
             'auto-select': {
                 type: Boolean,
-                description: 'Automatically select the message when only one is generated',
+                description: 'Automatically select the first successfully generated message (skips the picker and the confirmation)',
                 alias: 's',
                 default: false,
             },
@@ -220,48 +213,47 @@ export default command(
             let commitMsgSubscription: Subscription | null = null;
 
             try {
-                // Store choices with metadata for later lookup
-                const choiceMap = new Map<string, RewriteChoice>();
-                // Progress shown next to the bar as (done/total): final results (including
-                // error entries) over the number of AI requests. Streaming previews excluded.
-                const totalRequests = aiRequestManager.countRequests(availableAIs);
-                let settledRequests = 0;
+                let selectedValue: string | undefined;
 
-                // Mount up front: the library's loading bar hides the question while the list
-                // is empty, so there is no premature question + empty list. The bar animates
-                // through generation and the list fills in as messages stream.
-                const commitMsgInquirer = commitMsgPromptManager.initPrompt();
-                // Single emission: carries both `isLoading: true` and the initial (0/N) progress.
-                commitMsgPromptManager.updateLoaderProgress(settledRequests, totalRequests);
+                if (autoSelect) {
+                    selectedValue = (await selectMessageAutomatically(aiRequestManager, availableAIs, commitMsgPromptManager)).value;
+                } else {
+                    // Progress shown next to the bar as (done/total): final results (including
+                    // error entries) over the number of AI requests. Streaming previews excluded.
+                    const totalRequests = aiRequestManager.countRequests(availableAIs);
+                    let settledRequests = 0;
 
-                commitMsgSubscription = aiRequestManager.createCommitMsgRequests$(availableAIs).subscribe({
-                    next: (choice: ReactiveListChoice) => {
-                        const rewriteChoice = choice as RewriteChoice;
-                        if (rewriteChoice.value) {
-                            choiceMap.set(rewriteChoice.value, rewriteChoice);
-                        }
-                        const isFinalResult = !('streamKey' in choice);
-                        if (isFinalResult && settledRequests < totalRequests) {
-                            settledRequests++;
-                            commitMsgPromptManager.updateLoaderProgress(settledRequests, totalRequests);
-                        }
-                        commitMsgPromptManager.refreshChoices(choice);
-                    },
-                    error: error => {
-                        console.error('Commit message generation error:', error);
-                        commitMsgPromptManager.checkErrorOnChoices();
-                    },
-                    complete: () => commitMsgPromptManager.checkErrorOnChoices(),
-                });
+                    // Mount up front: the library's loading bar hides the question while the list
+                    // is empty, so there is no premature question + empty list. The bar animates
+                    // through generation and the list fills in as messages stream.
+                    const commitMsgInquirer = commitMsgPromptManager.initPrompt();
+                    // Single emission: carries both `isLoading: true` and the initial (0/N) progress.
+                    commitMsgPromptManager.updateLoaderProgress(settledRequests, totalRequests);
 
-                const commitMsgInquirerResult = await commitMsgInquirer;
+                    commitMsgSubscription = aiRequestManager.createCommitMsgRequests$(availableAIs).subscribe({
+                        next: (choice: ReactiveListChoice) => {
+                            const isFinalResult = !('streamKey' in choice);
+                            if (isFinalResult && settledRequests < totalRequests) {
+                                settledRequests++;
+                                commitMsgPromptManager.updateLoaderProgress(settledRequests, totalRequests);
+                            }
+                            commitMsgPromptManager.refreshChoices(choice);
+                        },
+                        error: error => {
+                            console.error('Commit message generation error:', error);
+                            commitMsgPromptManager.checkErrorOnChoices();
+                        },
+                        complete: () => commitMsgPromptManager.checkErrorOnChoices(),
+                    });
 
-                const selectedValue = commitMsgInquirerResult.aicommit2Prompt?.value;
+                    const commitMsgInquirerResult = await commitMsgInquirer;
+                    selectedValue = commitMsgInquirerResult.aicommit2Prompt?.value;
+                }
+
                 if (!selectedValue) {
                     throw new KnownError('An error occurred! No selected message');
                 }
 
-                const selectedChoice = choiceMap.get(selectedValue);
                 let selectedMessage = selectedValue;
 
                 if (edit) {
@@ -285,7 +277,7 @@ export default command(
                 }
 
                 // Auto-select or confirm — skip the explicit confirm prompt below
-                if (confirm || (autoSelect && availableAIs.length === 1)) {
+                if (confirm || autoSelect) {
                     await performRewrite(selectedMessage, commitHash);
                     return;
                 }

--- a/src/commands/select-message.ts
+++ b/src/commands/select-message.ts
@@ -1,0 +1,105 @@
+import { ReactiveListChoice } from 'inquirer-reactive-list-prompt';
+
+import { AIRequestManager } from '../managers/ai-request.manager.js';
+import { ConsoleManager } from '../managers/console.manager.js';
+import { ReactivePromptManager, commitMsgLoader } from '../managers/reactive-prompt.manager.js';
+import { ModelName } from '../utils/config.js';
+import { KnownError } from '../utils/error.js';
+import { barSpinner } from '../utils/loading-bar.js';
+
+import type { Subscription } from 'rxjs';
+
+const consoleManager = new ConsoleManager();
+
+/**
+ * Extended ReactiveListChoice with provider metadata for selection tracking
+ */
+export interface CommitChoice extends ReactiveListChoice {
+    provider?: string;
+    model?: string;
+}
+
+/**
+ * Result of commit message selection
+ */
+export interface CommitMessageResult {
+    value: string;
+    provider: string;
+    model: string;
+}
+
+/**
+ * Pick a message without mounting the interactive prompt — what `--auto-select` does for
+ * both `aicommit2` and `aicommit2 rewrite`. Resolves on the first usable message rather
+ * than waiting for every provider: with several configured, waiting for the slowest would
+ * make --auto-select slower than picking from the list by hand.
+ */
+export const selectMessageAutomatically = async (
+    aiRequestManager: AIRequestManager,
+    availableAIs: ModelName[],
+    commitMsgPromptManager: ReactivePromptManager
+): Promise<CommitMessageResult> => {
+    const messages: CommitChoice[] = [];
+    // The promise executor runs synchronously, so this is assigned before subscribing below
+    let resolveSelection!: (message: CommitChoice | null) => void;
+    const selection = new Promise<CommitChoice | null>(resolve => {
+        resolveSelection = resolve;
+    });
+
+    // No prompt is mounted here, so the console bar is the only feedback during the wait
+    consoleManager.showLoader(commitMsgLoader.startOption.text, barSpinner);
+
+    const commitMsgSubscription: Subscription = aiRequestManager.createCommitMsgRequests$(availableAIs).subscribe({
+        next: (choice: ReactiveListChoice) => {
+            commitMsgPromptManager.refreshChoices(choice);
+            // Skip streaming preview/sentinel choices — only collect final results
+            const isStreamingChoice = 'streamKey' in choice;
+            if (isStreamingChoice) {
+                return;
+            }
+            const commitChoice = choice as CommitChoice;
+            messages.push(commitChoice);
+            if (commitChoice.value && !commitChoice.isError && !commitChoice.disabled) {
+                resolveSelection(commitChoice);
+            }
+        },
+        error: error => {
+            console.error('Commit message generation error:', error);
+            commitMsgPromptManager.checkErrorOnChoices(false);
+            resolveSelection(null);
+        },
+        complete: () => {
+            commitMsgPromptManager.checkErrorOnChoices(false);
+            resolveSelection(null);
+        },
+    });
+
+    try {
+        const selectedMessage = await selection;
+
+        consoleManager.stopLoader();
+
+        if (!selectedMessage || !selectedMessage.value) {
+            // No prompt was mounted, so nothing has rendered the per-model error lines.
+            // Print them before failing — otherwise the run ends with no explanation.
+            messages.forEach(msg => {
+                if (msg.isError && msg.name) {
+                    consoleManager.print(msg.name);
+                }
+            });
+            throw new KnownError('No valid commit message was generated');
+        }
+
+        consoleManager.print(`\n${selectedMessage.name}\n`);
+        return {
+            value: selectedMessage.value,
+            provider: selectedMessage.provider || 'unknown',
+            model: selectedMessage.model || 'unknown',
+        };
+    } finally {
+        // Stops this process from reacting to the providers that lost the race. Streaming
+        // requests are aborted on teardown; a non-streaming request is already in flight and
+        // runs to completion regardless, its result simply discarded.
+        commitMsgSubscription.unsubscribe();
+    }
+};

--- a/src/managers/ai-request.manager.ts
+++ b/src/managers/ai-request.manager.ts
@@ -50,6 +50,17 @@ export class AIRequestManager {
         return this.createServiceRequests$(modelNames, 'review');
     };
 
+    /**
+     * Number of requests the given providers will fan out to. Each provider fires one
+     * request per configured model, so this is not the same as the provider count.
+     */
+    countRequests = (modelNames: ModelName[]): number => {
+        return modelNames.reduce((total, ai) => {
+            const { model } = this.config[ai];
+            return total + (Array.isArray(model) ? model.length : 1);
+        }, 0);
+    };
+
     private createServiceRequests$ = (modelNames: ModelName[], requestType: 'commit' | 'review'): Observable<ReactiveListChoice> => {
         return from(modelNames).pipe(
             mergeMap(ai => this.createProviderRequests$(ai, requestType)),

--- a/src/managers/ai-request.manager.ts
+++ b/src/managers/ai-request.manager.ts
@@ -55,10 +55,16 @@ export class AIRequestManager {
      * request per configured model, so this is not the same as the provider count.
      */
     countRequests = (modelNames: ModelName[]): number => {
-        return modelNames.reduce((total, ai) => {
-            const { model } = this.config[ai];
-            return total + (Array.isArray(model) ? model.length : 1);
-        }, 0);
+        return modelNames.reduce((total, ai) => total + this.getModels(ai).length, 0);
+    };
+
+    /**
+     * Models a provider is configured with. Single source for the fan-out width, so the
+     * progress counter and the requests themselves cannot drift apart.
+     */
+    private getModels = (ai: ModelName): string[] => {
+        const { model } = this.config[ai];
+        return Array.isArray(model) ? model : [model];
     };
 
     private createServiceRequests$ = (modelNames: ModelName[], requestType: 'commit' | 'review'): Observable<ReactiveListChoice> => {
@@ -69,10 +75,7 @@ export class AIRequestManager {
     };
 
     private createProviderRequests$ = (ai: ModelName, requestType: 'commit' | 'review'): Observable<ReactiveListChoice> => {
-        const config = this.config[ai];
-        const models = Array.isArray(config.model) ? config.model : [config.model];
-
-        return from(models).pipe(mergeMap(model => this.createModelRequest$(ai, model, requestType)));
+        return from(this.getModels(ai)).pipe(mergeMap(model => this.createModelRequest$(ai, model, requestType)));
     };
 
     private createModelRequest$ = (ai: ModelName, model: string, requestType: 'commit' | 'review'): Observable<ReactiveListChoice> => {

--- a/src/utils/config-validator.ts
+++ b/src/utils/config-validator.ts
@@ -1,0 +1,136 @@
+import { SERVICE_NAME_PATTERN, getConfigParsers, getConfigPath, readConfigFile } from './config.js';
+import { fileExists } from './fs.js';
+
+export interface ConfigIssue {
+    level: 'error' | 'warning';
+    // `locale`, `OPENAI.model` or `[openai]` — where in the file the issue is
+    location: string;
+    message: string;
+    hint?: string;
+}
+
+export interface ConfigValidation {
+    configPath: string;
+    exists: boolean;
+    issues: ConfigIssue[];
+}
+
+const isSection = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const editDistance = (a: string, b: string): number => {
+    let previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+    for (let i = 1; i <= a.length; i++) {
+        const current = [i];
+        for (let j = 1; j <= b.length; j++) {
+            const substitution = previous[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1);
+            current[j] = Math.min(previous[j] + 1, current[j - 1] + 1, substitution);
+        }
+        previous = current;
+    }
+    return previous[b.length];
+};
+
+/**
+ * Closest accepted key for a key nothing accepts — case differences first, then typos.
+ */
+const suggestKey = (key: string, knownKeys: string[]): string | undefined => {
+    const lowered = key.toLowerCase();
+    const caseMatch = knownKeys.find(known => known.toLowerCase() === lowered);
+    if (caseMatch) {
+        return caseMatch;
+    }
+    const [closest] = knownKeys
+        .map(known => ({ known, distance: editDistance(lowered, known.toLowerCase()) }))
+        .filter(({ distance }) => distance <= 2)
+        .sort((first, second) => first.distance - second.distance);
+    return closest?.known;
+};
+
+const unknownKeyIssue = (location: string, key: string, knownKeys: string[]): ConfigIssue => {
+    const suggestion = suggestKey(key, knownKeys);
+    return {
+        level: 'warning',
+        location,
+        message: 'Unknown option, silently ignored.',
+        hint: suggestion && `Did you mean \`${suggestion}\`?`,
+    };
+};
+
+const invalidSectionIssue = (name: string): ConfigIssue => {
+    const upperCased = name.toUpperCase();
+    return {
+        level: 'error',
+        location: `[${name}]`,
+        message: 'Invalid section name, so the whole section is ignored. Names must be uppercase letters, numbers and underscores.',
+        hint: SERVICE_NAME_PATTERN.test(upperCased) ? `Did you mean [${upperCased}]?` : undefined,
+    };
+};
+
+/**
+ * Run one parser over one raw value, turning a rejection into an issue instead of aborting.
+ * `getConfig` throws on the first bad value; validation reports every one of them.
+ */
+const validateValue = (parse: (value: any) => any, location: string, value: unknown): ConfigIssue | null => {
+    try {
+        parse(value);
+        return null;
+    } catch (error) {
+        return { level: 'error', location, message: (error as Error).message };
+    }
+};
+
+/**
+ * Check the config file against the parsers the rest of the CLI runs on, reporting the
+ * three things a normal run stays silent about: sections dropped for an invalid name,
+ * keys no parser accepts, and values a parser rejects.
+ */
+export const validateConfigFile = async (): Promise<ConfigValidation> => {
+    const configPath = await getConfigPath();
+    const exists = await fileExists(configPath);
+    if (!exists) {
+        return { configPath, exists, issues: [] };
+    }
+
+    // Throws a KnownError naming the file when it cannot be read or parsed
+    const config = await readConfigFile();
+    const generalParsers = getConfigParsers();
+    const generalKeys = Object.keys(generalParsers);
+    const issues: ConfigIssue[] = [];
+
+    for (const [name, value] of Object.entries(config)) {
+        if (!isSection(value)) {
+            const parse = generalParsers[name];
+            if (!parse) {
+                issues.push(unknownKeyIssue(name, name, generalKeys));
+                continue;
+            }
+            const issue = validateValue(parse, name, value);
+            if (issue) {
+                issues.push(issue);
+            }
+            continue;
+        }
+
+        if (!SERVICE_NAME_PATTERN.test(name)) {
+            issues.push(invalidSectionIssue(name));
+            continue;
+        }
+
+        const sectionParsers = getConfigParsers(name);
+        const sectionKeys = Object.keys(sectionParsers);
+        for (const [key, rawValue] of Object.entries(value)) {
+            const parse = sectionParsers[key];
+            if (!parse) {
+                issues.push(unknownKeyIssue(`${name}.${key}`, key, sectionKeys));
+                continue;
+            }
+            const issue = validateValue(parse, `${name}.${key}`, rawValue);
+            if (issue) {
+                issues.push(issue);
+            }
+        }
+    }
+
+    return { configPath, exists, issues };
+};

--- a/src/utils/config-validator.ts
+++ b/src/utils/config-validator.ts
@@ -1,4 +1,4 @@
-import { SERVICE_NAME_PATTERN, getConfigParsers, getConfigPath, readConfigFile } from './config.js';
+import { ConfigParser, SERVICE_NAME_PATTERN, getConfigParsers, getConfigPath, readConfigFile } from './config.js';
 import { fileExists } from './fs.js';
 
 export interface ConfigIssue {
@@ -71,7 +71,7 @@ const invalidSectionIssue = (name: string): ConfigIssue => {
  * Run one parser over one raw value, turning a rejection into an issue instead of aborting.
  * `getConfig` throws on the first bad value; validation reports every one of them.
  */
-const validateValue = (parse: (value: any) => any, location: string, value: unknown): ConfigIssue | null => {
+const validateValue = (parse: ConfigParser, location: string, value: unknown): ConfigIssue | null => {
     try {
         parse(value);
         return null;

--- a/src/utils/config-validator.ts
+++ b/src/utils/config-validator.ts
@@ -81,6 +81,25 @@ const validateValue = (parse: ConfigParser, location: string, value: unknown): C
 };
 
 /**
+ * Everything wrong with one `key=value`: either no parser accepts the key, or the parser
+ * that does rejects the value. Same rule for a top-level option and a key inside a section.
+ */
+const checkEntry = (
+    parsers: Record<string, ConfigParser>,
+    knownKeys: string[],
+    location: string,
+    key: string,
+    value: unknown
+): ConfigIssue[] => {
+    const parse = parsers[key];
+    if (!parse) {
+        return [unknownKeyIssue(location, key, knownKeys)];
+    }
+    const issue = validateValue(parse, location, value);
+    return issue ? [issue] : [];
+};
+
+/**
  * Check the config file against the parsers the rest of the CLI runs on, reporting the
  * three things a normal run stays silent about: sections dropped for an invalid name,
  * keys no parser accepts, and values a parser rejects.
@@ -100,15 +119,7 @@ export const validateConfigFile = async (): Promise<ConfigValidation> => {
 
     for (const [name, value] of Object.entries(config)) {
         if (!isSection(value)) {
-            const parse = generalParsers[name];
-            if (!parse) {
-                issues.push(unknownKeyIssue(name, name, generalKeys));
-                continue;
-            }
-            const issue = validateValue(parse, name, value);
-            if (issue) {
-                issues.push(issue);
-            }
+            issues.push(...checkEntry(generalParsers, generalKeys, name, name, value));
             continue;
         }
 
@@ -120,15 +131,7 @@ export const validateConfigFile = async (): Promise<ConfigValidation> => {
         const sectionParsers = getConfigParsers(name);
         const sectionKeys = Object.keys(sectionParsers);
         for (const [key, rawValue] of Object.entries(value)) {
-            const parse = sectionParsers[key];
-            if (!parse) {
-                issues.push(unknownKeyIssue(`${name}.${key}`, key, sectionKeys));
-                continue;
-            }
-            const issue = validateValue(parse, `${name}.${key}`, rawValue);
-            if (issue) {
-                issues.push(issue);
-            }
+            issues.push(...checkEntry(sectionParsers, sectionKeys, `${name}.${key}`, key, rawValue));
         }
     }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1449,14 +1449,21 @@ export const printConfigPath = async () => {
 };
 
 /**
+ * One config key's parser. `any` on both sides is deliberate and matches the declared type
+ * of `modelConfigParsers`: parsers are heterogeneous per key (string, number, boolean, JSON
+ * object) and receive raw INI/CLI/env input, so neither side narrows at this seam.
+ */
+export type ConfigParser = (value: any) => any;
+
+/**
  * Parsers that accept the config keys of a section, or of the top level when no service
  * name is given. Backs `aicommit2 config validate`, which reports keys no parser accepts.
  */
-export const getConfigParsers = (serviceName?: string): Record<string, (value: any) => any> => {
+export const getConfigParsers = (serviceName?: string): Record<string, ConfigParser> => {
     if (!serviceName) {
-        return generalConfigParsers as Record<string, (value: any) => any>;
+        return generalConfigParsers as Record<string, ConfigParser>;
     }
-    return (modelConfigParsers[serviceName as ModelName] || createConfigParser(serviceName)) as Record<string, (value: any) => any>;
+    return (modelConfigParsers[serviceName as ModelName] || createConfigParser(serviceName)) as Record<string, ConfigParser>;
 };
 
 const createConfigParser = (serviceName: string) => ({

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -122,17 +122,14 @@ export const AICOMMIT_CONFIG_FILE_PATH = path.join(AICOMMIT_CONFIG_DIR, 'config.
 export const AICOMMIT_MAIN_LOG_FILE_PATH = path.join(AICOMMIT_LOGS_DIR, 'aicommit2-%DATE%.log');
 export const AICOMMIT_EXCEPTION_LOG_FILE_PATH = path.join(AICOMMIT_LOGS_DIR, 'exceptions-%DATE%.log');
 
+// Configuration section name rules (only uppercase letters, numbers and underscores allowed)
+export const SERVICE_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+
 const findAllServices = (config: RawConfig): string[] => {
     const sections = Object.keys(config);
 
     // Include all built-in services and added sections
-    const allServices = new Set([
-        ...BUILTIN_SERVICES,
-        ...sections.filter(section =>
-            // Validate configuration section name rules (only uppercase letters and underscores allowed)
-            /^[A-Z][A-Z0-9_]*$/.test(section)
-        ),
-    ]);
+    const allServices = new Set([...BUILTIN_SERVICES, ...sections.filter(section => SERVICE_NAME_PATTERN.test(section))]);
 
     return Array.from(allServices);
 };
@@ -1220,14 +1217,16 @@ export const readConfigFile = async (): Promise<RawConfig> => {
         cachedConfigPath = configPath;
         return cachedRawConfig;
     } catch (error) {
-        // If the file doesn't exist or can't be read, return an empty config
+        loadedConfigPath = undefined;
+        // Not having a config file at all is a supported setup — everything can come from
+        // CLI flags and environment variables.
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-            loadedConfigPath = undefined;
             return {};
         }
-        console.error(`Error reading config file ${configPath}:`, error);
-        loadedConfigPath = undefined;
-        return {};
+        // Anything else (unreadable file, malformed INI) used to fall through to an empty
+        // config, so the run failed much later with an unrelated error. Fail here instead,
+        // naming the file that could not be read.
+        throw new KnownError(`Failed to read config file ${configPath}: ${(error as Error).message}`);
     }
 };
 
@@ -1333,7 +1332,7 @@ export const setConfigs = async (keyValues: [key: string, value: any][]) => {
         }
 
         // Custom services
-        const isValidServiceName = /^[A-Z][A-Z0-9_]*$/.test(modelName);
+        const isValidServiceName = SERVICE_NAME_PATTERN.test(modelName);
         if (!isValidServiceName) {
             throw new KnownError(`Invalid service name: ${modelName}. Service names must be uppercase letters, numbers, and underscores.`);
         }
@@ -1447,6 +1446,17 @@ export const listConfigs = async () => {
 
 export const printConfigPath = async () => {
     console.log(await getConfigPath());
+};
+
+/**
+ * Parsers that accept the config keys of a section, or of the top level when no service
+ * name is given. Backs `aicommit2 config validate`, which reports keys no parser accepts.
+ */
+export const getConfigParsers = (serviceName?: string): Record<string, (value: any) => any> => {
+    if (!serviceName) {
+        return generalConfigParsers as Record<string, (value: any) => any>;
+    }
+    return (modelConfigParsers[serviceName as ModelName] || createConfigParser(serviceName)) as Record<string, (value: any) => any>;
 };
 
 const createConfigParser = (serviceName: string) => ({

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -11,6 +11,7 @@ describe('aicommit2', ({ runTestSuite }) => {
     runTestSuite(import('./specs/bedrock/index.js'));
     runTestSuite(import('./specs/config.js'));
     runTestSuite(import('./specs/config-env.js'));
+    runTestSuite(import('./specs/config-validate.js'));
     runTestSuite(import('./specs/git-hook.js'));
     runTestSuite(import('./specs/hook-args.js'));
     runTestSuite(import('./specs/vcs/index.js'));

--- a/tests/specs/cli/auto-select.ts
+++ b/tests/specs/cli/auto-select.ts
@@ -1,0 +1,129 @@
+import http from 'http';
+import { AddressInfo } from 'net';
+
+import { expect, testSuite } from 'manten';
+
+import { createFixture, createGit } from '../../utils.js';
+
+const MOCK_MESSAGE = 'feat: add mock feature';
+
+/**
+ * Minimal OpenAI-compatible endpoint. Two `compatible` providers point at it, which is
+ * what makes these tests exercise the multi-provider path without any API key.
+ */
+const startMockProvider = async (): Promise<{ url: string; close: () => Promise<void> }> => {
+    const server = http.createServer((request, response) => {
+        request.on('data', () => {});
+        request.on('end', () => {
+            response.writeHead(200, { 'Content-Type': 'application/json' });
+            response.end(
+                JSON.stringify({
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: 'assistant', content: JSON.stringify([{ subject: MOCK_MESSAGE, body: '', footer: '' }]) },
+                            finish_reason: 'stop',
+                        },
+                    ],
+                })
+            );
+        });
+    });
+
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as AddressInfo;
+
+    return {
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>(resolve => server.close(() => resolve())),
+    };
+};
+
+const twoProviderConfig = (url: string) =>
+    ['[MOCK]', 'compatible=true', `url=${url}`, 'path=/v1', 'key=sk-test', 'model=m1', 'stream=false', ''].join('\n') +
+    ['[MOCK2]', 'compatible=true', `url=${url}`, 'path=/v1', 'key=sk-test', 'model=m2', 'stream=false', ''].join('\n');
+
+export default testSuite(({ describe }) => {
+    describe('auto-select', async ({ test }) => {
+        // Issue #262: `--auto-select` used to be ignored unless exactly one provider was
+        // configured, so a non-interactive run fell through to the picker and waited for Enter.
+        test('selects a message without prompting when several providers are configured', async () => {
+            const mock = await startMockProvider();
+            const { fixture, aicommit2 } = await createFixture({
+                '.aicommit2': twoProviderConfig(mock.url),
+                'data.json': '{"a":1}',
+            });
+            const git = await createGit(fixture.path);
+            await git('add', ['data.json']);
+
+            const { stdout, exitCode } = await aicommit2(['--all', '--dry-run', '--auto-select'], {
+                env: { AICOMMIT_CONFIG_PATH: `${fixture.path}/.aicommit2` },
+                reject: false,
+                // Bound the run: regressing the gate parks it at the picker, and a hung CI
+                // job is a much worse signal than a failed assertion
+                timeout: 30_000,
+            });
+
+            expect(exitCode).toBe(0);
+            expect(stdout).toMatch(MOCK_MESSAGE);
+
+            await mock.close();
+            await fixture.rm();
+        });
+
+        test('commits without asking for confirmation', async () => {
+            const mock = await startMockProvider();
+            const { fixture, aicommit2 } = await createFixture({
+                '.aicommit2': twoProviderConfig(mock.url),
+                'data.json': '{"a":1}',
+            });
+            const git = await createGit(fixture.path);
+            await git('add', ['data.json']);
+
+            const { exitCode } = await aicommit2(['--all', '--auto-select'], {
+                env: { AICOMMIT_CONFIG_PATH: `${fixture.path}/.aicommit2` },
+                reject: false,
+                // Bound the run: regressing the gate parks it at the picker, and a hung CI
+                // job is a much worse signal than a failed assertion
+                timeout: 30_000,
+            });
+
+            expect(exitCode).toBe(0);
+            const { stdout: commitMessage } = await git('log', ['--pretty=format:%s']);
+            expect(commitMessage).toBe(MOCK_MESSAGE);
+
+            await mock.close();
+            await fixture.rm();
+        });
+
+        // Nothing renders the per-model error lines in auto-select mode, so they used to be
+        // swallowed entirely and the run ended with no explanation.
+        test('prints the per-model errors when every provider fails', async () => {
+            const mock = await startMockProvider();
+            const config = twoProviderConfig(mock.url);
+            await mock.close();
+
+            const { fixture, aicommit2 } = await createFixture({
+                '.aicommit2': config,
+                'data.json': '{"a":1}',
+            });
+            const git = await createGit(fixture.path);
+            await git('add', ['data.json']);
+
+            const { stdout, exitCode } = await aicommit2(['--all', '--dry-run', '--auto-select'], {
+                env: { AICOMMIT_CONFIG_PATH: `${fixture.path}/.aicommit2` },
+                reject: false,
+                // Bound the run: regressing the gate parks it at the picker, and a hung CI
+                // job is a much worse signal than a failed assertion
+                timeout: 30_000,
+            });
+
+            expect(exitCode).toBe(1);
+            expect(stdout).toMatch('M1');
+            expect(stdout).toMatch('M2');
+            expect(stdout).toMatch('No valid commit message was generated');
+
+            await fixture.rm();
+        });
+    });
+});

--- a/tests/specs/cli/auto-select.ts
+++ b/tests/specs/cli/auto-select.ts
@@ -1,6 +1,7 @@
 import http from 'http';
 import { AddressInfo } from 'net';
 
+import { type Options } from 'execa';
 import { expect, testSuite } from 'manten';
 
 import { createFixture, createGit } from '../../utils.js';
@@ -40,90 +41,104 @@ const startMockProvider = async (): Promise<{ url: string; close: () => Promise<
 };
 
 const twoProviderConfig = (url: string) =>
-    ['[MOCK]', 'compatible=true', `url=${url}`, 'path=/v1', 'key=sk-test', 'model=m1', 'stream=false', ''].join('\n') +
-    ['[MOCK2]', 'compatible=true', `url=${url}`, 'path=/v1', 'key=sk-test', 'model=m2', 'stream=false', ''].join('\n');
+    [
+        ['MOCK', 'm1'],
+        ['MOCK2', 'm2'],
+    ]
+        .map(([name, model]) => `[${name}]\ncompatible=true\nurl=${url}\npath=/v1\nkey=sk-test\nmodel=${model}\nstream=false\n`)
+        .join('');
+
+type Fixture = Awaited<ReturnType<typeof createFixture>>;
+type Git = Awaited<ReturnType<typeof createGit>>;
+
+/**
+ * A git repo with one staged file and both mock providers configured, plus the run options
+ * every test here needs. `serverUp: false` closes the mock first, so every provider fails.
+ */
+const withMockProviders = async (
+    serverUp: boolean,
+    run: (context: { aicommit2: Fixture['aicommit2']; options: Options; git: Git }) => Promise<void>
+) => {
+    const mock = await startMockProvider();
+    const config = twoProviderConfig(mock.url);
+    if (!serverUp) {
+        await mock.close();
+    }
+
+    const { fixture, aicommit2 } = await createFixture({ '.aicommit2': config, 'data.json': '{"a":1}', 'data2.json': '{"b":2}' });
+    const git = await createGit(fixture.path);
+    await git('add', ['data.json']);
+
+    try {
+        await run({
+            aicommit2,
+            git,
+            options: {
+                env: { AICOMMIT_CONFIG_PATH: `${fixture.path}/.aicommit2` },
+                reject: false,
+                // Bound the run: regressing the gate parks it at the picker, and a hung CI
+                // job is a much worse signal than a failed assertion
+                timeout: 30_000,
+            },
+        });
+    } finally {
+        if (serverUp) {
+            await mock.close();
+        }
+        await fixture.rm();
+    }
+};
 
 export default testSuite(({ describe }) => {
     describe('auto-select', async ({ test }) => {
         // Issue #262: `--auto-select` used to be ignored unless exactly one provider was
         // configured, so a non-interactive run fell through to the picker and waited for Enter.
         test('selects a message without prompting when several providers are configured', async () => {
-            const mock = await startMockProvider();
-            const { fixture, aicommit2 } = await createFixture({
-                '.aicommit2': twoProviderConfig(mock.url),
-                'data.json': '{"a":1}',
+            await withMockProviders(true, async ({ aicommit2, options }) => {
+                const { stdout, exitCode } = await aicommit2(['--all', '--dry-run', '--auto-select'], options);
+
+                expect(exitCode).toBe(0);
+                expect(stdout).toMatch(MOCK_MESSAGE);
             });
-            const git = await createGit(fixture.path);
-            await git('add', ['data.json']);
-
-            const { stdout, exitCode } = await aicommit2(['--all', '--dry-run', '--auto-select'], {
-                env: { AICOMMIT_CONFIG_PATH: `${fixture.path}/.aicommit2` },
-                reject: false,
-                // Bound the run: regressing the gate parks it at the picker, and a hung CI
-                // job is a much worse signal than a failed assertion
-                timeout: 30_000,
-            });
-
-            expect(exitCode).toBe(0);
-            expect(stdout).toMatch(MOCK_MESSAGE);
-
-            await mock.close();
-            await fixture.rm();
         });
 
         test('commits without asking for confirmation', async () => {
-            const mock = await startMockProvider();
-            const { fixture, aicommit2 } = await createFixture({
-                '.aicommit2': twoProviderConfig(mock.url),
-                'data.json': '{"a":1}',
+            await withMockProviders(true, async ({ aicommit2, options, git }) => {
+                const { exitCode } = await aicommit2(['--all', '--auto-select'], options);
+                expect(exitCode).toBe(0);
+
+                const { stdout: commitMessage } = await git('log', ['--pretty=format:%s']);
+                expect(commitMessage).toBe(MOCK_MESSAGE);
             });
-            const git = await createGit(fixture.path);
-            await git('add', ['data.json']);
+        });
 
-            const { exitCode } = await aicommit2(['--all', '--auto-select'], {
-                env: { AICOMMIT_CONFIG_PATH: `${fixture.path}/.aicommit2` },
-                reject: false,
-                // Bound the run: regressing the gate parks it at the picker, and a hung CI
-                // job is a much worse signal than a failed assertion
-                timeout: 30_000,
+        // `rewrite` owns a second copy of the flag, so it needs its own coverage — the gate
+        // was originally fixed in only one of the two commands.
+        test('rewrite selects a message without prompting', async () => {
+            await withMockProviders(true, async ({ aicommit2, options, git }) => {
+                // Two commits: the root commit has no parent, so it has no diff to rewrite from
+                await git('commit', ['-m', 'chore: initial']);
+                await git('add', ['data2.json']);
+                await git('commit', ['-m', 'chore: second']);
+
+                const { stdout, exitCode } = await aicommit2(['rewrite', '--dry-run', '--auto-select'], options);
+
+                expect(exitCode).toBe(0);
+                expect(stdout).toMatch(MOCK_MESSAGE);
             });
-
-            expect(exitCode).toBe(0);
-            const { stdout: commitMessage } = await git('log', ['--pretty=format:%s']);
-            expect(commitMessage).toBe(MOCK_MESSAGE);
-
-            await mock.close();
-            await fixture.rm();
         });
 
         // Nothing renders the per-model error lines in auto-select mode, so they used to be
         // swallowed entirely and the run ended with no explanation.
         test('prints the per-model errors when every provider fails', async () => {
-            const mock = await startMockProvider();
-            const config = twoProviderConfig(mock.url);
-            await mock.close();
+            await withMockProviders(false, async ({ aicommit2, options }) => {
+                const { stdout, exitCode } = await aicommit2(['--all', '--dry-run', '--auto-select'], options);
 
-            const { fixture, aicommit2 } = await createFixture({
-                '.aicommit2': config,
-                'data.json': '{"a":1}',
+                expect(exitCode).toBe(1);
+                expect(stdout).toMatch('M1');
+                expect(stdout).toMatch('M2');
+                expect(stdout).toMatch('No valid commit message was generated');
             });
-            const git = await createGit(fixture.path);
-            await git('add', ['data.json']);
-
-            const { stdout, exitCode } = await aicommit2(['--all', '--dry-run', '--auto-select'], {
-                env: { AICOMMIT_CONFIG_PATH: `${fixture.path}/.aicommit2` },
-                reject: false,
-                // Bound the run: regressing the gate parks it at the picker, and a hung CI
-                // job is a much worse signal than a failed assertion
-                timeout: 30_000,
-            });
-
-            expect(exitCode).toBe(1);
-            expect(stdout).toMatch('M1');
-            expect(stdout).toMatch('M2');
-            expect(stdout).toMatch('No valid commit message was generated');
-
-            await fixture.rm();
         });
     });
 });

--- a/tests/specs/cli/index.ts
+++ b/tests/specs/cli/index.ts
@@ -3,6 +3,7 @@ import { testSuite } from 'manten';
 export default testSuite(({ describe }) => {
     describe('CLI', ({ runTestSuite }) => {
         runTestSuite(import('./error-cases.js'));
+        runTestSuite(import('./auto-select.js'));
         runTestSuite(import('./commits.js'));
         runTestSuite(import('./rewrite.js'));
     });

--- a/tests/specs/config-validate.ts
+++ b/tests/specs/config-validate.ts
@@ -1,0 +1,79 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import { expect, testSuite } from 'manten';
+
+import { createFixture } from '../utils.js';
+
+export default testSuite(({ describe }) => {
+    describe('config validate', async ({ test }) => {
+        const runValidate = async (configContent: string) => {
+            const { fixture, aicommit2 } = await createFixture();
+            const configPath = path.join(fixture.path, '.aicommit2');
+            await fs.writeFile(configPath, configContent);
+
+            const result = await aicommit2(['config', 'validate'], {
+                env: { AICOMMIT_CONFIG_PATH: configPath },
+                reject: false,
+            });
+
+            await fixture.rm();
+            return result;
+        };
+
+        test('accepts a valid config', async () => {
+            const { stdout, exitCode } = await runValidate('[OPENAI]\nkey=sk-test\nmodel=gpt-4o\ntemperature=0.7\n');
+
+            expect(stdout).toMatch('Configuration is valid');
+            expect(exitCode).toBe(0);
+        });
+
+        test('reports a section name that is silently dropped', async () => {
+            const { stdout, exitCode } = await runValidate('[openai]\nkey=sk-test\n');
+
+            expect(stdout).toMatch('[openai]');
+            expect(stdout).toMatch('Invalid section name');
+            expect(stdout).toMatch('Did you mean [OPENAI]?');
+            expect(exitCode).toBe(1);
+        });
+
+        test('reports an unknown option and suggests the closest one', async () => {
+            const { stdout, exitCode } = await runValidate('[OPENAI]\nkey=sk-test\nmodell=gpt-4o\n');
+
+            expect(stdout).toMatch('OPENAI.modell');
+            expect(stdout).toMatch('Unknown option');
+            expect(stdout).toMatch('Did you mean `model`?');
+            // Unknown options are a warning, not a failure
+            expect(exitCode).toBe(0);
+        });
+
+        test('reports every invalid value, not just the first', async () => {
+            const { stdout, exitCode } = await runValidate('[OPENAI]\ntemperature=99\nmaxTokens=abc\n');
+
+            expect(stdout).toMatch('OPENAI.temperature');
+            expect(stdout).toMatch('OPENAI.maxTokens');
+            expect(exitCode).toBe(1);
+        });
+
+        test('reports an invalid top level option value', async () => {
+            const { stdout, exitCode } = await runValidate('generate=nope\n');
+
+            expect(stdout).toMatch('generate');
+            expect(stdout).toMatch('Must be an integer');
+            expect(exitCode).toBe(1);
+        });
+
+        test('passes when no config file exists', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+
+            const { stdout, exitCode } = await aicommit2(['config', 'validate'], {
+                env: { AICOMMIT_CONFIG_PATH: path.join(fixture.path, 'missing-config') },
+                reject: false,
+            });
+
+            expect(stdout).toMatch('No configuration file found');
+            expect(exitCode).toBe(0);
+            await fixture.rm();
+        });
+    });
+});

--- a/tests/specs/config-validate.ts
+++ b/tests/specs/config-validate.ts
@@ -63,6 +63,38 @@ export default testSuite(({ describe }) => {
             expect(exitCode).toBe(1);
         });
 
+        // An unreadable config file used to be swallowed, so the run continued with an empty
+        // config and failed later with something unrelated.
+        test('names the config file when it cannot be read', async () => {
+            const { fixture, aicommit2 } = await createFixture({ 'not-a-file/keep': '' });
+            const configPath = path.join(fixture.path, 'not-a-file');
+
+            const { stdout, exitCode } = await aicommit2(['config', 'validate'], {
+                env: { AICOMMIT_CONFIG_PATH: configPath },
+                reject: false,
+            });
+
+            expect(stdout).toMatch('Failed to read config file');
+            expect(stdout).toMatch(configPath);
+            expect(exitCode).toBe(1);
+            await fixture.rm();
+        });
+
+        test('reports an unreadable config file on a normal run instead of failing later', async () => {
+            const { fixture, aicommit2 } = await createFixture({ 'not-a-file/keep': '' });
+            const configPath = path.join(fixture.path, 'not-a-file');
+
+            const { stdout, exitCode } = await aicommit2(['--all', '--dry-run', '--auto-select'], {
+                env: { AICOMMIT_CONFIG_PATH: configPath },
+                reject: false,
+            });
+
+            expect(stdout).toMatch('Failed to read config file');
+            expect(stdout).toMatch('config validate');
+            expect(exitCode).toBe(1);
+            await fixture.rm();
+        });
+
         test('passes when no config file exists', async () => {
             const { fixture, aicommit2 } = await createFixture();
 

--- a/tests/specs/managers/ai-request-manager.ts
+++ b/tests/specs/managers/ai-request-manager.ts
@@ -1,0 +1,42 @@
+import { expect, testSuite } from 'manten';
+
+import { AIRequestManager } from '../../../src/managers/ai-request.manager.js';
+import { ModelName, ValidConfig } from '../../../src/utils/config.js';
+import { GitDiff } from '../../../src/utils/vcs.js';
+
+const emptyDiff: GitDiff = { files: [], diff: '' };
+
+const buildManager = (models: Record<string, string | string[]>) => {
+    const config = Object.fromEntries(Object.entries(models).map(([name, model]) => [name, { model }])) as unknown as ValidConfig;
+    return new AIRequestManager(config, emptyDiff);
+};
+
+export default testSuite(({ describe }) => {
+    describe('AIRequestManager', ({ describe: describeGroup }) => {
+        describeGroup('countRequests', ({ test }) => {
+            test('counts one request per provider with a single model', () => {
+                const manager = buildManager({ OPENAI: 'gpt-4o', GEMINI: 'gemini-2.0-flash' });
+
+                expect(manager.countRequests(['OPENAI', 'GEMINI'] as ModelName[])).toBe(2);
+            });
+
+            test('counts every model of a multi-model provider', () => {
+                const manager = buildManager({ OPENAI: ['gpt-4o', 'gpt-4o-mini', 'o3'], GEMINI: 'gemini-2.0-flash' });
+
+                expect(manager.countRequests(['OPENAI', 'GEMINI'] as ModelName[])).toBe(4);
+            });
+
+            test('counts only the providers it is given', () => {
+                const manager = buildManager({ OPENAI: ['gpt-4o', 'o3'], GEMINI: 'gemini-2.0-flash' });
+
+                expect(manager.countRequests(['GEMINI'] as ModelName[])).toBe(1);
+            });
+
+            test('returns zero for no providers', () => {
+                const manager = buildManager({ OPENAI: 'gpt-4o' });
+
+                expect(manager.countRequests([])).toBe(0);
+            });
+        });
+    });
+});

--- a/tests/specs/managers/index.ts
+++ b/tests/specs/managers/index.ts
@@ -3,5 +3,6 @@ import { testSuite } from 'manten';
 export default testSuite(({ describe }) => {
     describe('Managers', ({ runTestSuite }) => {
         runTestSuite(import('./reactive-prompt-manager.js'));
+        runTestSuite(import('./ai-request-manager.js'));
     });
 });


### PR DESCRIPTION
## #262 — `--auto-select` was ignored with more than one provider

`--auto-select` (`-s`) was gated on `availableAIs.length === 1`, so it was silently dropped
whenever more than one provider was configured. `aicommit2 -acds` then fell through to the
interactive picker and waited for Enter, which reads as a hang now that the loading bar
covers the question until generation finishes. The same gate guarded the post-generation
commit confirmation, so `-as` (auto-commit without dry-run) stopped twice.

Both gates now honour the flag regardless of provider count. It resolves on the first
successfully generated message instead of waiting for every provider, so it is never slower
than picking from the list by hand.

`aicommit2 rewrite` carried a third copy of the same gate. It has its own `--auto-select`
flag with the same alias and description, and it mounted the picker unconditionally, so
`aicommit2 rewrite --auto-select` still hung. The auto-select path now lives in
`src/commands/select-message.ts` and both commands call it.

### Behavior change

Users running `-s` with **more than one provider configured** previously got a picker and a
confirmation prompt. They now get an automatic commit with neither. This applies to
`aicommit2` and `aicommit2 rewrite` alike. Single-provider users are unaffected — that path
already skipped both.

### Related fixes in the same area

- **Progress counter.** The `(done/total)` next to the loading bar counted providers, but
  requests fan out per configured model. A provider with three models plus another with one
  showed `(2/2)` for four requests. `AIRequestManager.countRequests()` now reports the real
  total, sharing a single `getModels` with the code that fans the requests out.
- **Invisible errors.** Failures in the auto-select path produced no output at all, because
  no prompt is mounted to render the per-model error lines. They are printed before the run
  fails.

## #263 — `aicommit2 config validate`

A hand-edited `config.ini` can be wrong in ways a normal run never mentions: a section whose
name is not uppercase (`[openai]`) is dropped by the service-name filter, and a key no parser
accepts (`modell=gpt-4o`) is skipped silently, so the provider simply never activates.

`config validate` reports both, plus every invalid value, and exits non-zero on error:

```
Config file: ~/.config/aicommit2/config.ini

✖ [openai]: Invalid section name, so the whole section is ignored. Names must be uppercase letters, numbers and underscores. Did you mean [OPENAI]?
! OPENAI.modell: Unknown option, silently ignored. Did you mean `model`?
✖ OPENAI.temperature: Invalid config property temperature: Must be decimal between 0 and 2

2 error(s), 1 warning(s)
```

It reports over the parsers the rest of the CLI already runs on — no second set of rules to
keep in sync. Its messages are the ones a real run would print, except it reports all of them
instead of stopping at the first. Unknown keys are warnings; dropped sections and rejected
values are errors. Typos get a suggestion from the closest accepted key. Values are checked
after environment variable expansion.

`doctor` is deliberately untouched: it owns live provider health checks, this owns the static
file.

### Runtime changes to review carefully

- **`readConfigFile` now throws** a `KnownError` naming the file on any non-ENOENT failure,
  instead of logging to stderr and returning `{}`. A missing file is still a supported setup
  and still returns an empty config.

  Inherited by every caller: `getConfig`, `listConfigs`, `config get`/`del`/`path`, `doctor`,
  and the git-hook entry points. All of them funnel through the CLI handler or their own
  `.catch`, so the failure prints one line and exits 1. The behavior change is that a
  permissions-broken config file now fails loudly where it previously degraded to defaults —
  which is the point of the issue.

- **The CLI entry point** awaited `getConfig` with nothing catching above it, so a config
  error printed as a raw unhandled rejection with a stack dump. It now prints the message and
  points at `config validate`.

## Verification

Against a local OpenAI-compatible mock, non-interactive, and confirmed by hand against real
providers (Groq / Gemma3 / Gemini):

- Three providers, `-acds` → auto-selects and exits 0, no Enter required.
- `-as` → commits with no confirmation prompt.
- `-ad` → the bar counts every request, not every provider.
- `rewrite --dry-run --auto-select` → no picker.
- Server down, `-s` → both per-model error lines printed, exit 1.
- `config validate` against a config with a lowercase section, a typo'd key, an out-of-range
  temperature and a bad URL → 4 errors, 1 warning, exit 1. Valid config → "Configuration is
  valid", exit 0. No config file → warning, exit 0.
- Unreadable config, then `aicommit2 -acds` → one `✖ Failed to read config file …` line
  instead of a stack dump.

`pnpm test`: 403 passed, 16 new in `tests/specs/cli/auto-select.ts`,
`tests/specs/config-validate.ts`, and `tests/specs/managers/ai-request-manager.ts`. Reverting
the gate to `availableAIs.length === 1` turns the auto-select tests red.
