### PR TITLE
fix(auto-select): honour --auto-select in the code review path, and improve config validate hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ Run `aicommit2 --help` to see all available options grouped by category.
 - `--confirm` or `-y`: Skip confirmation when committing after message generation (default: **false**)
 - `--auto-select` or `-s`: Automatically select the first successfully generated message (default: **false**)
   - Runs non-interactively: skips both the message picker and the commit confirmation, regardless of how many AI providers are configured
+  - With [`codeReview`](./docs/settings.md#codereview) enabled, the first review is printed in full instead of opening the review list. Critical findings are printed as a warning and the run continues, since there is no prompt to answer
 - `--edit` or `-e`: Open the AI-generated commit message in your default editor (default: **false**)
 - `--clipboard` or `-c`: Copy the selected message to clipboard and exit **without committing** (default: **false**)
 - `--dry-run` or `-d`: Generate commit message without committing (default: **false**)

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -332,6 +332,8 @@ aicommit2 config set codeReview=true
 
 > NOTE: When enabled, aicommit2 will perform a code review before generating commit messages.
 
+With `--auto-select`, the review list never opens: the first review to come back is printed in full and the run continues. Critical findings are reported as a warning rather than stopping the run, because there is no confirmation prompt left to answer.
+
 <img src="https://github.com/tak-bro/aicommit2/blob/main/img/code_review.gif?raw=true" alt="CODE_REVIEW" />
 
 **CAUTION**

--- a/src/commands/aicommit2.ts
+++ b/src/commands/aicommit2.ts
@@ -9,7 +9,7 @@ import { ReactiveListChoice } from 'inquirer-reactive-list-prompt';
 import { lastValueFrom, toArray } from 'rxjs';
 
 import { getAvailableAIs } from './get-available-ais.js';
-import { CommitChoice, CommitMessageResult, selectMessageAutomatically } from './select-message.js';
+import { CommitChoice, CommitMessageResult, selectCodeReviewAutomatically, selectMessageAutomatically } from './select-message.js';
 import { AIRequestManager } from '../managers/ai-request.manager.js';
 import { ConsoleManager } from '../managers/console.manager.js';
 import {
@@ -23,7 +23,7 @@ import { recordSelection } from '../services/stats/index.js';
 import { ModelName, RawConfig, applyDisableLowerCaseToConfig, applyIncludeBodyToConfig, getConfig } from '../utils/config.js';
 import { ErrorCode, ErrorMessages } from '../utils/error-messages.js';
 import { KnownError, handleCliError } from '../utils/error.js';
-import { validateSystemPrompt } from '../utils/prompt.js';
+import { CRITICAL_ISSUES_MARKER, validateSystemPrompt } from '../utils/prompt.js';
 import {
     CommitOptions,
     applyDiffCompression,
@@ -171,7 +171,7 @@ export default async (
 
         const codeReviewAIs = getAvailableAIs(config, 'review');
         if (codeReviewAIs.length > 0) {
-            await handleCodeReview(aiRequestManager, codeReviewAIs);
+            await handleCodeReview(aiRequestManager, codeReviewAIs, autoSelect);
         }
 
         const commitResult = await handleCommitMessage(aiRequestManager, availableAIs, autoSelect);
@@ -260,11 +260,21 @@ export default async (
         process.exit(1);
     });
 
-async function handleCodeReview(aiRequestManager: AIRequestManager, availableAIs: ModelName[]) {
+async function handleCodeReview(aiRequestManager: AIRequestManager, availableAIs: ModelName[], autoSelect: boolean) {
     const codeReviewPromptManager = new ReactivePromptManager(codeReviewLoader);
     let codeReviewSubscription: Subscription | null = null;
 
     try {
+        if (autoSelect) {
+            const review = await selectCodeReviewAutomatically(aiRequestManager, availableAIs, codeReviewPromptManager);
+            // The interactive path asks whether to continue on critical issues. There is no
+            // prompt here, and --auto-select means the run goes through, so warn instead.
+            if (review.includes(CRITICAL_ISSUES_MARKER)) {
+                consoleManager.printWarning('Critical issues found in code review.');
+            }
+            return;
+        }
+
         const codeReviewInquirer = codeReviewPromptManager.initPrompt({
             ...DEFAULT_INQUIRER_OPTIONS,
             name: 'codeReviewPrompt',
@@ -295,7 +305,7 @@ async function handleCodeReview(aiRequestManager: AIRequestManager, availableAIs
 
         consoleManager.moveCursorUp();
 
-        const hasCritical = selectedCodeReview.includes('<!-- HAS_CRITICAL_ISSUES -->');
+        const hasCritical = selectedCodeReview.includes(CRITICAL_ISSUES_MARKER);
         const confirmMessage = hasCritical
             ? 'Critical issues found in code review. Continue without fixing?'
             : 'Will you continue without changing the code?';

--- a/src/commands/select-message.ts
+++ b/src/commands/select-message.ts
@@ -2,12 +2,12 @@ import { ReactiveListChoice } from 'inquirer-reactive-list-prompt';
 
 import { AIRequestManager } from '../managers/ai-request.manager.js';
 import { ConsoleManager } from '../managers/console.manager.js';
-import { ReactivePromptManager, commitMsgLoader } from '../managers/reactive-prompt.manager.js';
+import { ReactivePromptManager, codeReviewLoader, commitMsgLoader } from '../managers/reactive-prompt.manager.js';
 import { ModelName } from '../utils/config.js';
 import { KnownError } from '../utils/error.js';
 import { barSpinner } from '../utils/loading-bar.js';
 
-import type { Subscription } from 'rxjs';
+import type { Observable, Subscription } from 'rxjs';
 
 const consoleManager = new ConsoleManager();
 
@@ -28,78 +28,129 @@ export interface CommitMessageResult {
     model: string;
 }
 
+interface AutoChoiceRequest {
+    requests$: Observable<ReactiveListChoice>;
+    promptManager: ReactivePromptManager;
+    loaderText: string;
+    errorLogPrefix: string;
+    emptyErrorMessage: string;
+}
+
 /**
- * Pick a message without mounting the interactive prompt — what `--auto-select` does for
- * both `aicommit2` and `aicommit2 rewrite`. Resolves on the first usable message rather
- * than waiting for every provider: with several configured, waiting for the slowest would
- * make --auto-select slower than picking from the list by hand.
+ * Take the first usable choice off a request stream without mounting the interactive
+ * prompt — what `--auto-select` does. Resolves on the first usable result rather than
+ * waiting for every provider: with several configured, waiting for the slowest would make
+ * --auto-select slower than picking from the list by hand.
+ */
+const resolveFirstChoice = async ({
+    requests$,
+    promptManager,
+    loaderText,
+    errorLogPrefix,
+    emptyErrorMessage,
+}: AutoChoiceRequest): Promise<CommitChoice> => {
+    // Only the error lines are ever read back, and a review body is large enough that
+    // keeping every losing choice around for the run is worth avoiding
+    const errorNames: string[] = [];
+    // The promise executor runs synchronously, so this is assigned before subscribing below
+    let resolveSelection!: (choice: CommitChoice | null) => void;
+    const selection = new Promise<CommitChoice | null>(resolve => {
+        resolveSelection = resolve;
+    });
+
+    // No prompt is mounted here, so the console bar is the only feedback during the wait
+    consoleManager.showLoader(loaderText, barSpinner);
+
+    const subscription: Subscription = requests$.subscribe({
+        next: (choice: ReactiveListChoice) => {
+            promptManager.refreshChoices(choice);
+            // Skip streaming preview/sentinel choices — only collect final results
+            const isStreamingChoice = 'streamKey' in choice;
+            if (isStreamingChoice) {
+                return;
+            }
+            const settledChoice = choice as CommitChoice;
+            if (settledChoice.value && !settledChoice.isError && !settledChoice.disabled) {
+                resolveSelection(settledChoice);
+                return;
+            }
+            if (settledChoice.isError && settledChoice.name) {
+                errorNames.push(settledChoice.name);
+            }
+        },
+        error: error => {
+            console.error(errorLogPrefix, error);
+            promptManager.checkErrorOnChoices(false);
+            resolveSelection(null);
+        },
+        complete: () => {
+            promptManager.checkErrorOnChoices(false);
+            resolveSelection(null);
+        },
+    });
+
+    try {
+        const selected = await selection;
+
+        consoleManager.stopLoader();
+
+        if (!selected || !selected.value) {
+            // No prompt was mounted, so nothing has rendered the per-model error lines.
+            // Print them before failing — otherwise the run ends with no explanation.
+            errorNames.forEach(name => consoleManager.print(name));
+            throw new KnownError(emptyErrorMessage);
+        }
+
+        return selected;
+    } finally {
+        // Stops this process from reacting to the providers that lost the race. Streaming
+        // requests are aborted on teardown; a non-streaming request is already in flight and
+        // runs to completion regardless, its result simply discarded.
+        subscription.unsubscribe();
+    }
+};
+
+/**
+ * `--auto-select` commit message pick, shared by `aicommit2` and `aicommit2 rewrite`.
  */
 export const selectMessageAutomatically = async (
     aiRequestManager: AIRequestManager,
     availableAIs: ModelName[],
     commitMsgPromptManager: ReactivePromptManager
 ): Promise<CommitMessageResult> => {
-    const messages: CommitChoice[] = [];
-    // The promise executor runs synchronously, so this is assigned before subscribing below
-    let resolveSelection!: (message: CommitChoice | null) => void;
-    const selection = new Promise<CommitChoice | null>(resolve => {
-        resolveSelection = resolve;
+    const selected = await resolveFirstChoice({
+        requests$: aiRequestManager.createCommitMsgRequests$(availableAIs),
+        promptManager: commitMsgPromptManager,
+        loaderText: commitMsgLoader.startOption.text,
+        errorLogPrefix: 'Commit message generation error:',
+        emptyErrorMessage: 'No valid commit message was generated',
     });
 
-    // No prompt is mounted here, so the console bar is the only feedback during the wait
-    consoleManager.showLoader(commitMsgLoader.startOption.text, barSpinner);
+    consoleManager.print(`\n${selected.name}\n`);
+    return {
+        value: selected.value,
+        provider: selected.provider || 'unknown',
+        model: selected.model || 'unknown',
+    };
+};
 
-    const commitMsgSubscription: Subscription = aiRequestManager.createCommitMsgRequests$(availableAIs).subscribe({
-        next: (choice: ReactiveListChoice) => {
-            commitMsgPromptManager.refreshChoices(choice);
-            // Skip streaming preview/sentinel choices — only collect final results
-            const isStreamingChoice = 'streamKey' in choice;
-            if (isStreamingChoice) {
-                return;
-            }
-            const commitChoice = choice as CommitChoice;
-            messages.push(commitChoice);
-            if (commitChoice.value && !commitChoice.isError && !commitChoice.disabled) {
-                resolveSelection(commitChoice);
-            }
-        },
-        error: error => {
-            console.error('Commit message generation error:', error);
-            commitMsgPromptManager.checkErrorOnChoices(false);
-            resolveSelection(null);
-        },
-        complete: () => {
-            commitMsgPromptManager.checkErrorOnChoices(false);
-            resolveSelection(null);
-        },
+/**
+ * `--auto-select` code review pick. The picker never mounts, so the review body is printed
+ * in full — otherwise an opted-in review would produce no visible output at all.
+ */
+export const selectCodeReviewAutomatically = async (
+    aiRequestManager: AIRequestManager,
+    availableAIs: ModelName[],
+    codeReviewPromptManager: ReactivePromptManager
+): Promise<string> => {
+    const selected = await resolveFirstChoice({
+        requests$: aiRequestManager.createCodeReviewRequests$(availableAIs),
+        promptManager: codeReviewPromptManager,
+        loaderText: codeReviewLoader.startOption.text,
+        errorLogPrefix: 'Code review request error:',
+        emptyErrorMessage: 'An error occurred! No selected code review',
     });
 
-    try {
-        const selectedMessage = await selection;
-
-        consoleManager.stopLoader();
-
-        if (!selectedMessage || !selectedMessage.value) {
-            // No prompt was mounted, so nothing has rendered the per-model error lines.
-            // Print them before failing — otherwise the run ends with no explanation.
-            messages.forEach(msg => {
-                if (msg.isError && msg.name) {
-                    consoleManager.print(msg.name);
-                }
-            });
-            throw new KnownError('No valid commit message was generated');
-        }
-
-        consoleManager.print(`\n${selectedMessage.name}\n`);
-        return {
-            value: selectedMessage.value,
-            provider: selectedMessage.provider || 'unknown',
-            model: selectedMessage.model || 'unknown',
-        };
-    } finally {
-        // Stops this process from reacting to the providers that lost the race. Streaming
-        // requests are aborted on teardown; a non-streaming request is already in flight and
-        // runs to completion regardless, its result simply discarded.
-        commitMsgSubscription.unsubscribe();
-    }
+    consoleManager.print(`\n${selected.name}\n\n${selected.value}\n`);
+    return selected.value;
 };

--- a/src/services/ai/ai.service.ts
+++ b/src/services/ai/ai.service.ts
@@ -7,7 +7,14 @@ import { buildCommitContext } from '../../utils/commit-context/index.js';
 import { CommitType, ModelConfig, ModelName, ModelNameDisplay } from '../../utils/config.js';
 import { ErrorCode, ErrorCodeType, detectErrorCode, getPlainErrorMessage, httpStatusToErrorCode } from '../../utils/error-messages.js';
 import { logger } from '../../utils/logger.js';
-import { CommitContext, DEFAULT_PROMPT_OPTIONS, PromptOptions, generatePrompt, generateUserPrompt } from '../../utils/prompt.js';
+import {
+    CRITICAL_ISSUES_MARKER,
+    CommitContext,
+    DEFAULT_PROMPT_OPTIONS,
+    PromptOptions,
+    generatePrompt,
+    generateUserPrompt,
+} from '../../utils/prompt.js';
 import { isReasoningCapableModel } from '../../utils/reasoning-models.js';
 import { IncrementalJsonParser } from '../../utils/stream-json-parser.js';
 import { getFirstWordsFrom, safeJsonParse } from '../../utils/utils.js';
@@ -660,7 +667,7 @@ export abstract class AIService {
     };
 
     private formatReviewAsMarkdown = (summary: string, items: CodeReviewItem[], hasCritical: boolean): string => {
-        const criticalMarker = hasCritical ? '\n<!-- HAS_CRITICAL_ISSUES -->\n' : '';
+        const criticalMarker = hasCritical ? `\n${CRITICAL_ISSUES_MARKER}\n` : '';
         const lines: string[] = [`## Summary\n${summary}${criticalMarker}\n`];
 
         const severityOrder: CodeReviewSeverity[] = ['critical', 'warning', 'suggestion', 'praise'];

--- a/src/utils/config-validator.ts
+++ b/src/utils/config-validator.ts
@@ -31,29 +31,45 @@ const editDistance = (a: string, b: string): number => {
     return previous[b.length];
 };
 
+const SETTINGS_DOCS_URL = 'https://github.com/tak-bro/aicommit2/blob/main/docs/settings.md';
+
 /**
- * Closest accepted key for a key nothing accepts — case differences first, then typos.
+ * Anchor for one option in the settings reference. Headings there are `### <key>`, and
+ * GitHub lowercases them into the fragment.
  */
-const suggestKey = (key: string, knownKeys: string[]): string | undefined => {
+const docsLinkFor = (key: string): string => `${SETTINGS_DOCS_URL}#${key.toLowerCase()}`;
+
+const MAX_SUGGESTIONS = 3;
+
+/**
+ * Accepted keys close enough to a key nothing accepts — an exact case difference on its
+ * own, otherwise up to three typo candidates. Deliberately not the full accepted list: a
+ * service section has dozens of keys and dumping them buries the answer.
+ */
+const suggestKeys = (key: string, knownKeys: string[]): string[] => {
     const lowered = key.toLowerCase();
     const caseMatch = knownKeys.find(known => known.toLowerCase() === lowered);
     if (caseMatch) {
-        return caseMatch;
+        return [caseMatch];
     }
-    const [closest] = knownKeys
+    return knownKeys
         .map(known => ({ known, distance: editDistance(lowered, known.toLowerCase()) }))
         .filter(({ distance }) => distance <= 2)
-        .sort((first, second) => first.distance - second.distance);
-    return closest?.known;
+        .sort((first, second) => first.distance - second.distance)
+        .slice(0, MAX_SUGGESTIONS)
+        .map(({ known }) => known);
 };
 
 const unknownKeyIssue = (location: string, key: string, knownKeys: string[]): ConfigIssue => {
-    const suggestion = suggestKey(key, knownKeys);
+    const suggestions = suggestKeys(key, knownKeys);
     return {
         level: 'warning',
         location,
         message: 'Unknown option, silently ignored.',
-        hint: suggestion && `Did you mean \`${suggestion}\`?`,
+        hint:
+            suggestions.length > 0
+                ? `Did you mean ${suggestions.map(suggestion => `\`${suggestion}\``).join(', ')}? See ${SETTINGS_DOCS_URL}`
+                : `Supported options: ${SETTINGS_DOCS_URL}`,
     };
 };
 
@@ -63,7 +79,7 @@ const invalidSectionIssue = (name: string): ConfigIssue => {
         level: 'error',
         location: `[${name}]`,
         message: 'Invalid section name, so the whole section is ignored. Names must be uppercase letters, numbers and underscores.',
-        hint: SERVICE_NAME_PATTERN.test(upperCased) ? `Did you mean [${upperCased}]?` : undefined,
+        hint: SERVICE_NAME_PATTERN.test(upperCased) ? `Did you mean [${upperCased}]?` : `Supported sections: ${SETTINGS_DOCS_URL}`,
     };
 };
 
@@ -71,12 +87,14 @@ const invalidSectionIssue = (name: string): ConfigIssue => {
  * Run one parser over one raw value, turning a rejection into an issue instead of aborting.
  * `getConfig` throws on the first bad value; validation reports every one of them.
  */
-const validateValue = (parse: ConfigParser, location: string, value: unknown): ConfigIssue | null => {
+const validateValue = (parse: ConfigParser, location: string, key: string, value: unknown): ConfigIssue | null => {
     try {
         parse(value);
         return null;
     } catch (error) {
-        return { level: 'error', location, message: (error as Error).message };
+        // Parser messages carry no trailing period, so the hint would run straight into them
+        const message = (error as Error).message.replace(/\.?$/, '.');
+        return { level: 'error', location, message, hint: `Accepted values: ${docsLinkFor(key)}` };
     }
 };
 
@@ -95,7 +113,7 @@ const checkEntry = (
     if (!parse) {
         return [unknownKeyIssue(location, key, knownKeys)];
     }
-    const issue = validateValue(parse, location, value);
+    const issue = validateValue(parse, location, key, value);
     return issue ? [issue] : [];
 };
 

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -348,6 +348,12 @@ export const generatePrompt = (promptOptions: PromptOptions) => {
     return `${basePrompt}\n${suffix}`;
 };
 
+/**
+ * Embedded in a rendered code review that contains at least one critical item. The commit
+ * flow reads it back to decide what to ask or warn about before committing.
+ */
+export const CRITICAL_ISSUES_MARKER = '<!-- HAS_CRITICAL_ISSUES -->';
+
 export const isValidConventionalMessage = (message: string): boolean => {
     // TODO: check loosely for issue that message is not coming out
     // const conventionalReg =

--- a/tests/specs/cli/auto-select.ts
+++ b/tests/specs/cli/auto-select.ts
@@ -7,22 +7,41 @@ import { expect, testSuite } from 'manten';
 import { createFixture, createGit } from '../../utils.js';
 
 const MOCK_MESSAGE = 'feat: add mock feature';
+const MOCK_REVIEW_SUMMARY = 'Mock review summary';
+
+const commitMessageContent = JSON.stringify([{ subject: MOCK_MESSAGE, body: '', footer: '' }]);
+const codeReviewContent = (severity: string) =>
+    JSON.stringify({
+        summary: MOCK_REVIEW_SUMMARY,
+        items: [{ severity, category: 'correctness', title: 'Mock finding', description: 'Mock description', suggestion: '' }],
+    });
 
 /**
  * Minimal OpenAI-compatible endpoint. Two `compatible` providers point at it, which is
  * what makes these tests exercise the multi-provider path without any API key.
+ * Code review and commit message requests share the endpoint, so the prompt decides which
+ * response shape comes back.
  */
-const startMockProvider = async (): Promise<{ url: string; close: () => Promise<void> }> => {
+const startMockProvider = async (reviewSeverity = 'warning'): Promise<{ url: string; close: () => Promise<void> }> => {
     const server = http.createServer((request, response) => {
-        request.on('data', () => {});
+        let body = '';
+        request.on('data', chunk => {
+            body += chunk;
+        });
         request.on('end', () => {
+            // The prompt is JSON-escaped inside the request body, so match on a bare word
+            // only the code review prompt uses
+            const isCodeReviewRequest = body.includes('severity');
             response.writeHead(200, { 'Content-Type': 'application/json' });
             response.end(
                 JSON.stringify({
                     choices: [
                         {
                             index: 0,
-                            message: { role: 'assistant', content: JSON.stringify([{ subject: MOCK_MESSAGE, body: '', footer: '' }]) },
+                            message: {
+                                role: 'assistant',
+                                content: isCodeReviewRequest ? codeReviewContent(reviewSeverity) : commitMessageContent,
+                            },
                             finish_reason: 'stop',
                         },
                     ],
@@ -57,10 +76,11 @@ type Git = Awaited<ReturnType<typeof createGit>>;
  */
 const withMockProviders = async (
     serverUp: boolean,
-    run: (context: { aicommit2: Fixture['aicommit2']; options: Options; git: Git }) => Promise<void>
+    run: (context: { aicommit2: Fixture['aicommit2']; options: Options; git: Git }) => Promise<void>,
+    extra: { generalConfig?: string; reviewSeverity?: string } = {}
 ) => {
-    const mock = await startMockProvider();
-    const config = twoProviderConfig(mock.url);
+    const mock = await startMockProvider(extra.reviewSeverity);
+    const config = `${extra.generalConfig ?? ''}${twoProviderConfig(mock.url)}`;
     if (!serverUp) {
         await mock.close();
     }
@@ -126,6 +146,39 @@ export default testSuite(({ describe }) => {
                 expect(exitCode).toBe(0);
                 expect(stdout).toMatch(MOCK_MESSAGE);
             });
+        });
+
+        // The code review picker had no `--auto-select` check of its own, so an opted-in
+        // review parked the run at a list plus a confirmation before generation even started.
+        test('prints the code review without prompting', async () => {
+            await withMockProviders(
+                true,
+                async ({ aicommit2, options }) => {
+                    const { stdout, exitCode } = await aicommit2(['--all', '--dry-run', '--auto-select'], options);
+
+                    expect(exitCode).toBe(0);
+                    expect(stdout).toMatch(MOCK_REVIEW_SUMMARY);
+                    expect(stdout).toMatch('Mock finding');
+                    expect(stdout).toMatch(MOCK_MESSAGE);
+                },
+                { generalConfig: 'codeReview=true\n' }
+            );
+        });
+
+        // The picker asks whether to continue on critical findings. Nothing can answer that
+        // here, so the finding has to be visible in the output instead.
+        test('warns about a critical code review finding and still generates a message', async () => {
+            await withMockProviders(
+                true,
+                async ({ aicommit2, options }) => {
+                    const { stdout, exitCode } = await aicommit2(['--all', '--dry-run', '--auto-select'], options);
+
+                    expect(exitCode).toBe(0);
+                    expect(stdout).toMatch('Critical issues found in code review');
+                    expect(stdout).toMatch(MOCK_MESSAGE);
+                },
+                { generalConfig: 'codeReview=true\n', reviewSeverity: 'critical' }
+            );
         });
 
         // Nothing renders the per-model error lines in auto-select mode, so they used to be

--- a/tests/specs/config-validate.ts
+++ b/tests/specs/config-validate.ts
@@ -47,6 +47,33 @@ export default testSuite(({ describe }) => {
             expect(exitCode).toBe(0);
         });
 
+        test('offers several candidates when more than one option is close', async () => {
+            const { stdout, exitCode } = await runValidate('[OPENAI]\ntyp=conventional\n');
+
+            expect(stdout).toMatch('Did you mean');
+            expect(stdout).toMatch('`type`');
+            expect(stdout).toMatch('`topP`');
+            expect(exitCode).toBe(0);
+        });
+
+        // A typo too far from anything to guess used to produce a bare "Unknown option" line
+        // with no way forward.
+        test('points at the settings docs when nothing is close enough to suggest', async () => {
+            const { stdout, exitCode } = await runValidate('[OPENAI]\nnonsenseoption=1\n');
+
+            expect(stdout).toMatch('Unknown option');
+            expect(stdout).toMatch('Supported options');
+            expect(stdout).toMatch('docs/settings.md');
+            expect(exitCode).toBe(0);
+        });
+
+        test('links the settings entry for a rejected value', async () => {
+            const { stdout, exitCode } = await runValidate('[OPENAI]\ntemperature=99\n');
+
+            expect(stdout).toMatch('docs/settings.md#temperature');
+            expect(exitCode).toBe(1);
+        });
+
         test('reports every invalid value, not just the first', async () => {
             const { stdout, exitCode } = await runValidate('[OPENAI]\ntemperature=99\nmaxTokens=abc\n');
 


### PR DESCRIPTION
## Summary

Two follow-ups from the v2.10.0 issue threads.

**#262 follow-up.** `--auto-select` documents a run with no prompts, but the code review path never checked the flag. With `codeReview=true` an `-acds` run still mounted a review list and a confirmation before message generation started, so it stopped twice. The review now resolves on the first result and prints it in full — the list that used to render it never opens. Critical findings print a warning and the run continues: the interactive path only flips the default answer, which a human can override, and a non-interactive run has no such escape.

The reporter's actual request on that thread — that the first provider to respond is the one whose message lands in the clipboard — already works as asked and needed no change.

**#263 improvement.** `config validate` said what was wrong but not what to write instead. A typo more than two edits from any accepted key produced a bare `Unknown option` line, and rejected values named no reference. Unknown keys now offer up to three candidates, fall back to the settings docs when nothing is close, and rejected values link the entry for that key.

```
! OPENAI.typ: Unknown option, silently ignored. Did you mean `type`, `topP`? See .../docs/settings.md
! OPENAI.nonsenseoption: Unknown option, silently ignored. Supported options: .../docs/settings.md
✖ OPENAI.temperature: Invalid config property temperature: Must be decimal between 0 and 2. Accepted values: .../docs/settings.md#temperature
```

## Changes

| File | What |
|---|---|
| `src/commands/select-message.ts` | First-wins selection extracted into `resolveFirstChoice`; commit message and code review are now its two callers. Losing providers' choices are no longer retained — only their error lines |
| `src/commands/aicommit2.ts` | `handleCodeReview` takes `autoSelect` and returns early through the non-interactive path |
| `src/utils/prompt.ts`, `src/services/ai/ai.service.ts` | `CRITICAL_ISSUES_MARKER` constant replaces the literal that was repeated at the producing and consuming sites |
| `src/utils/config-validator.ts` | `suggestKeys` returns up to three candidates; docs links on unknown keys, unknown sections, and rejected values |
| `README.md`, `docs/settings.md` | `--auto-select` behaviour under `codeReview` |
| `tests/specs/cli/auto-select.ts`, `tests/specs/config-validate.ts` | 5 new tests |

## How to Test

```bash
pnpm build

# Config hints
printf '[openai]\nkey=sk-test\n\n[OPENAI]\ntyp=x\nnonsenseoption=1\ntemperature=99\n' > /tmp/c.ini
AICOMMIT_CONFIG_PATH=/tmp/c.ini ./dist/cli.mjs config validate   # exits 1, five hinted lines

# Auto-select paths (no API key needed — local mock provider)
pnpm test
```

## Risks

- **Critical review findings no longer block a non-interactive run.** With `codeReview=true` and `--auto-select`, a review reporting critical items prints a warning and the commit proceeds. This is the deliberate reading of "no prompts"; the interactive path is unchanged.
- The auto path still fans the review out to every configured provider and discards the losers, so an opted-in review costs the same tokens it did before.
- `Accepted values:` links a `docs/settings.md` anchor for every key, including ones without their own heading (`key`, `model`, `url`) — those land at the top of the page rather than a section.

## Alternatives considered

- **Stop the run on critical findings** (implemented first, then reverted). It mirrors the interactive default, but that default is overridable and this one would not be — a `-acds` script that worked in 2.10.0 would start exiting 1 with no flag to get past it.
- **Skip the review entirely under `--auto-select`.** Shortest path, but `codeReview` is opt-in: silently dropping it turns a flag about prompts into a flag that disables a feature.
- **Fan the review out to a single provider** to avoid paying for discarded responses. Rejected: it makes that provider a single point of failure and inherits its latency.
- **List every accepted key** when no suggestion is close. Rejected: a provider section accepts dozens, and git does not do this either.

## Known gap, not addressed here

An uppercase section name that is a typo — `[OPENAAI]` — still passes validation silently, because the same code path legitimately serves custom OpenAI-compatible sections. Warning on it would misfire on valid configs. Worth its own issue.

## Checklist

- [x] `pnpm lint` clean
- [x] `pnpm type-check` at baseline (67 pre-existing, none in touched files)
- [x] `pnpm build`
- [x] `pnpm test` — 408 pass, 0 fail (403 on `main`)
- [x] README and `docs/settings.md` updated
