### PR TITLE
feat: add Atlas Cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ _aicommit2_ automatically generates commit messages using AI. It supports [Git](
 | Provider | Default Model | Documentation |
 |----------|---------------|---------------|
 | OpenAI | `gpt-4o-mini` | [Guide](docs/providers/openai.md) |
+| Atlas Cloud | `qwen/qwen3.8-max` | [Guide](docs/providers/atlascloud.md) |
 | Copilot SDK (Preview) | `gpt-4.1` | [Guide](docs/providers/copilot-sdk.md) |
 | Claude Code (Preview) | `sonnet` | [Guide](docs/providers/claude-code.md) |
 | Gemini CLI (Preview) | *(CLI default)* | [Guide](docs/providers/gemini-cli.md) |
@@ -886,6 +887,8 @@ You can configure API keys using environment variables. This is particularly use
 ```bash
 # OpenAI
 OPENAI_API_KEY="your-openai-key"
+# Atlas Cloud
+ATLASCLOUD_API_KEY="your-atlascloud-key"
 # Anthropic
 ANTHROPIC_API_KEY="your-anthropic-key"
 # Google
@@ -969,6 +972,7 @@ aicommit2 config set \
 > 🔍 **Detailed Support Info**: Check each provider's documentation for specific limits and behaviors:
 >
 > - [OpenAI](docs/providers/openai.md)
+> - [Atlas Cloud](docs/providers/atlascloud.md)
 > - [Anthropic Claude](docs/providers/anthropic.md)
 > - [Gemini](docs/providers/gemini.md)
 > - [Mistral & Codestral](docs/providers/mistral.md)

--- a/docs/providers/atlascloud.md
+++ b/docs/providers/atlascloud.md
@@ -1,0 +1,36 @@
+# Atlas Cloud
+
+Atlas Cloud is available as a built-in OpenAI-compatible provider. The preset uses the Chat Completions endpoint at `https://api.atlascloud.ai/v1` and defaults to `qwen/qwen3.8-max`.
+
+## Configuration
+
+Set the API key through the environment:
+
+```sh
+export ATLASCLOUD_API_KEY="your-api-key"
+aicommit2 config set ATLASCLOUD.model="qwen/qwen3.8-max"
+```
+
+Or store the provider settings in the aicommit2 config:
+
+```sh
+aicommit2 config set ATLASCLOUD.key="your-api-key" \
+    ATLASCLOUD.model="qwen/qwen3.8-max"
+```
+
+The interactive setup wizard also includes the provider:
+
+```sh
+aicommit2 setup
+```
+
+## Settings
+
+| Setting | Description                     | Default                     |
+| ------- | ------------------------------- | --------------------------- |
+| `key`   | API key                         | `ATLASCLOUD_API_KEY`        |
+| `model` | Model identifier                | `qwen/qwen3.8-max`          |
+| `url`   | API host                        | `https://api.atlascloud.ai` |
+| `path`  | OpenAI-compatible API base path | `/v1`                       |
+
+`url` and `path` remain configurable for compatible gateways or deployment-specific routing.

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -23,6 +23,12 @@ const PROVIDER_INFO: Record<string, ProviderInfo> = {
         envKeyHint: 'OPENAI_API_KEY',
         defaultModel: 'gpt-4o-mini',
     },
+    ATLASCLOUD: {
+        displayName: 'Atlas Cloud',
+        authType: 'api-key',
+        envKeyHint: 'ATLASCLOUD_API_KEY',
+        defaultModel: 'qwen/qwen3.8-max',
+    },
     COPILOT_SDK: {
         displayName: 'GitHub Copilot SDK (Preview)',
         authType: 'none',
@@ -112,7 +118,7 @@ const PROVIDER_INFO: Record<string, ProviderInfo> = {
 };
 
 // Popular providers shown first for selection
-const POPULAR_PROVIDERS = ['OPENAI', 'OPENROUTER', 'ANTHROPIC', 'GEMINI', 'OLLAMA', 'GROQ', 'DEEPSEEK'];
+const POPULAR_PROVIDERS = ['OPENAI', 'ATLASCLOUD', 'OPENROUTER', 'ANTHROPIC', 'GEMINI', 'OLLAMA', 'GROQ', 'DEEPSEEK'];
 
 export default command(
     {

--- a/src/services/ai/atlascloud.service.ts
+++ b/src/services/ai/atlascloud.service.ts
@@ -1,0 +1,16 @@
+import chalk from 'chalk';
+
+import { AIServiceParams } from './ai.service.js';
+import { OpenAICompatibleService } from './openai-compatible.service.js';
+
+export class AtlasCloudService extends OpenAICompatibleService {
+    constructor(params: AIServiceParams) {
+        super({ ...params, keyName: 'ATLASCLOUD' });
+        this.colors = {
+            primary: '#111827',
+            secondary: '#ffffff',
+        };
+        this.serviceName = chalk.bgHex(this.colors.primary).hex(this.colors.secondary).bold(`[Atlas Cloud${this.formatModelSuffix()}]`);
+        this.errorPrefix = chalk.red.bold(`[Atlas Cloud${this.formatModelSuffix()}]`);
+    }
+}

--- a/src/services/ai/provider-registry.ts
+++ b/src/services/ai/provider-registry.ts
@@ -156,6 +156,7 @@ class ProviderRegistryClass {
      */
     private registerBuiltinProviders = (): void => {
         this.loaders.set('OPENAI', () => import('./openai.service.js').then(m => m.OpenAIService));
+        this.loaders.set('ATLASCLOUD', () => import('./atlascloud.service.js').then(m => m.AtlasCloudService));
         this.loaders.set('COPILOT_SDK', () => import('./copilot-sdk.service.js').then(m => m.CopilotSdkService));
         this.loaders.set('CLAUDE_CODE', () => import('./claude-code.service.js').then(m => m.ClaudeCodeService));
         this.loaders.set('GEMINI_CLI', () => import('./gemini-cli.service.js').then(m => m.GeminiCliService));

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -38,6 +38,7 @@ export const hasOwn = (object: unknown, key: PropertyKey) => hasOwnProperty.call
 
 export const BUILTIN_SERVICES = [
     'OPENAI',
+    'ATLASCLOUD',
     'COPILOT_SDK',
     'CLAUDE_CODE',
     'GEMINI_CLI',
@@ -438,6 +439,49 @@ const modelConfigParsers: Record<ModelName, Record<string, (value: any) => any>>
         },
         path: (path?: string) => path || '/v1/chat/completions',
         proxy: (proxy?: string) => proxy || '',
+        topP: generalConfigParsers.topP,
+        systemPrompt: generalConfigParsers.systemPrompt,
+        systemPromptPath: generalConfigParsers.systemPromptPath,
+        codeReviewPromptPath: generalConfigParsers.codeReviewPromptPath,
+        timeout: generalConfigParsers.timeout,
+        temperature: generalConfigParsers.temperature,
+        maxTokens: generalConfigParsers.maxTokens,
+        logging: generalConfigParsers.logging,
+        locale: generalConfigParsers.locale,
+        generate: generalConfigParsers.generate,
+        type: generalConfigParsers.type,
+        maxLength: generalConfigParsers.maxLength,
+        includeBody: generalConfigParsers.includeBody,
+        codeReview: generalConfigParsers.codeReview,
+        disabled: generalConfigParsers.disabled,
+        stream: generalConfigParsers.stream,
+        watchMode: generalConfigParsers.watchMode,
+        disableLowerCase: generalConfigParsers.disableLowerCase,
+        ticketExtraction: generalConfigParsers.ticketExtraction,
+        learnConventions: generalConfigParsers.learnConventions,
+        diffCompression: generalConfigParsers.diffCompression,
+        maxHunkLines: generalConfigParsers.maxHunkLines,
+        maxDiffLines: generalConfigParsers.maxDiffLines,
+        diffContext: generalConfigParsers.diffContext,
+    },
+    ATLASCLOUD: {
+        key: (key?: string) => key || '',
+        envKey: (envKey?: string) => envKey || '',
+        model: (model?: string | string[]): string[] => {
+            if (!model) {
+                return ['qwen/qwen3.8-max'];
+            }
+            const modelList = typeof model === 'string' ? model?.split(',') : model;
+            return modelList.map(m => m.trim()).filter(m => !!m && m.length > 0);
+        },
+        url: (host?: string) => {
+            if (!host) {
+                return 'https://api.atlascloud.ai';
+            }
+            parseAssert('ATLASCLOUD.url', /^https?:\/\//.test(host), 'Must be a valid URL');
+            return host;
+        },
+        path: (path?: string) => path || '/v1',
         topP: generalConfigParsers.topP,
         systemPrompt: generalConfigParsers.systemPrompt,
         systemPromptPath: generalConfigParsers.systemPromptPath,

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -3,6 +3,7 @@ import { describe } from 'manten';
 describe('aicommit2', ({ runTestSuite }) => {
     runTestSuite(import('./specs/cli/index.js'));
     runTestSuite(import('./specs/openai/index.js'));
+    runTestSuite(import('./specs/atlascloud/index.js'));
     runTestSuite(import('./specs/github-models/index.js'));
     runTestSuite(import('./specs/copilot-sdk/index.js'));
     runTestSuite(import('./specs/claude-code/index.js'));

--- a/tests/specs/atlascloud/index.ts
+++ b/tests/specs/atlascloud/index.ts
@@ -1,0 +1,89 @@
+import { expect, testSuite } from 'manten';
+
+import { AtlasCloudService } from '../../../src/services/ai/atlascloud.service.js';
+
+export default testSuite(async ({ describe }) => {
+    await describe('AtlasCloudService', async ({ test }) => {
+        await test('uses the Atlas Cloud OpenAI-compatible endpoint and provider identity', async () => {
+            const service = new AtlasCloudService({
+                config: {
+                    model: 'qwen/qwen3.8-max',
+                    key: 'test-api-key',
+                    url: 'https://api.atlascloud.ai',
+                    path: '/v1',
+                    maxTokens: 512,
+                    temperature: 0.2,
+                    topP: 0.9,
+                    timeout: 120000,
+                    logging: false,
+                    locale: 'en',
+                    generate: 1,
+                    type: 'conventional',
+                    maxLength: 50,
+                    systemPrompt: '',
+                    systemPromptPath: '',
+                    codeReviewPromptPath: '',
+                    stream: false,
+                } as any,
+                stagedDiff: { diff: 'diff --git a/file b/file', files: [] },
+                keyName: 'ATLASCLOUD',
+                branchName: 'main',
+            });
+
+            expect((service as any).openAI.baseURL).toBe('https://api.atlascloud.ai/v1');
+            expect((service as any).getProviderName()).toMatch('Atlas Cloud');
+        });
+
+        await test('sends the configured model through Chat Completions', async () => {
+            const service = new AtlasCloudService({
+                config: {
+                    model: 'qwen/qwen3.8-max',
+                    key: 'test-api-key',
+                    url: 'https://api.atlascloud.ai',
+                    path: '/v1',
+                    maxTokens: 512,
+                    temperature: 0.2,
+                    topP: 0.9,
+                    timeout: 120000,
+                    logging: false,
+                    locale: 'en',
+                    generate: 1,
+                    type: 'conventional',
+                    maxLength: 50,
+                    systemPrompt: '',
+                    systemPromptPath: '',
+                    codeReviewPromptPath: '',
+                    stream: false,
+                } as any,
+                stagedDiff: { diff: 'diff --git a/file b/file', files: [] },
+                keyName: 'ATLASCLOUD',
+                branchName: 'main',
+            });
+            let capturedPayload: Record<string, unknown> | undefined;
+
+            (service as any).openAI = {
+                chat: {
+                    completions: {
+                        create: async (payload: Record<string, unknown>) => {
+                            capturedPayload = payload;
+                            return {
+                                choices: [
+                                    {
+                                        message: {
+                                            content: '{"subject":"feat: add Atlas Cloud provider","body":"","footer":""}',
+                                        },
+                                    },
+                                ],
+                            };
+                        },
+                    },
+                },
+            };
+
+            const result = await (service as any).generateMessage('commit');
+
+            expect(capturedPayload?.model).toBe('qwen/qwen3.8-max');
+            expect(result[0].title).toBe('feat: add Atlas Cloud provider');
+        });
+    });
+});

--- a/tests/specs/config.ts
+++ b/tests/specs/config.ts
@@ -338,6 +338,35 @@ export default testSuite(({ describe }) => {
             });
         });
 
+        await describe('Atlas Cloud configuration', async ({ test }) => {
+            const envKeys = ['AICOMMIT_CONFIG_PATH', 'ATLASCLOUD_API_KEY'];
+
+            await test('uses built-in defaults and the provider-specific environment key', async () => {
+                const { fixture } = await createFixture();
+                const configPath = path.join(fixture.path, '.config', 'aicommit2', 'config.ini');
+                await ensureDirectoryExists(path.dirname(configPath));
+                await fs.writeFile(configPath, '[ATLASCLOUD]\n');
+
+                const snapshot = snapshotEnv(envKeys);
+                process.env.AICOMMIT_CONFIG_PATH = configPath;
+                process.env.ATLASCLOUD_API_KEY = 'test-atlas-key';
+                invalidateConfigCache();
+
+                const config = (await getConfig({}, [])) as ValidConfig;
+                const atlasCloud = config.ATLASCLOUD as any;
+
+                expect(atlasCloud.key).toBe('test-atlas-key');
+                expect(atlasCloud.model).toEqual(['qwen/qwen3.8-max']);
+                expect(atlasCloud.url).toBe('https://api.atlascloud.ai');
+                expect(atlasCloud.path).toBe('/v1');
+                expect(getAvailableAIs(config, 'commit')).toContain('ATLASCLOUD');
+
+                await fixture.rm();
+                restoreEnv(snapshot);
+                invalidateConfigCache();
+            });
+        });
+
         await describe('Copilot SDK configuration', async ({ test }) => {
             const envKeys = ['AICOMMIT_CONFIG_PATH', 'COPILOT_GITHUB_TOKEN', 'COPILOT_SDK_API_KEY'];
 


### PR DESCRIPTION
## Summary

- add Atlas Cloud as a built-in OpenAI-compatible provider with `ATLASCLOUD_API_KEY`
- default to `https://api.atlascloud.ai/v1` and `qwen/qwen3.8-max`
- expose the provider in interactive setup and document configuration
- cover provider routing and configuration defaults with focused tests

## Validation

- Atlas Cloud provider tests: 2 passed
- configuration suite: 38 passed
- full suite: 411 passed; the command retains the baseline non-zero exit caused by missing live `OPENAI_KEY` and an existing Manten runner error (unmodified base: 408 passed with the same errors)
- `eslint --cache .`
- `pkgroll --minify`
- real CLI dry-run using `qwen/qwen3.8-max` generated `feat(atlas): add atlas module flag`
- repo-wide `tsc --noEmit` retains the existing errors reproduced on the unmodified base