### PR TITLE
fix(doctor): report subscription-CLI providers by their opt-in signal

### DIFF
--- a/docs/providers/copilot-sdk.md
+++ b/docs/providers/copilot-sdk.md
@@ -138,8 +138,11 @@ aicommit2 doctor
 Expected healthy signal for `COPILOT_SDK`:
 
 - Copilot CLI detected
-- Model resolved — the configured model, or `gpt-4.1 (default)` when none is set (warns if the model is not in the known working list)
+- Model configured (warns if model is not in known working list)
 - Node runtime compatible
+
+Opting in with only a key or `COPILOT_GITHUB_TOKEN` and no `model` is reported as a warning: the
+provider is selected but sends no requests, because the fan-out is one request per configured model.
 
 Then validate generation in a git repo:
 

--- a/docs/providers/copilot-sdk.md
+++ b/docs/providers/copilot-sdk.md
@@ -138,7 +138,7 @@ aicommit2 doctor
 Expected healthy signal for `COPILOT_SDK`:
 
 - Copilot CLI detected
-- Model configured (warns if model is not in known working list)
+- Model resolved — the configured model, or `gpt-4.1 (default)` when none is set (warns if the model is not in the known working list)
 - Node runtime compatible
 
 Then validate generation in a git repo:

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -6,7 +6,6 @@ import { command } from 'cleye';
 import { getConfiguredModels, hasBedrockAccess, hasConfiguredModels, hasCopilotSdkAvailable } from './get-available-ais.js';
 import {
     ALL_COPILOT_SDK_KNOWN_MODELS,
-    COPILOT_SDK_DEFAULT_MODEL,
     buildCopilotSdkClientOptions,
     isCopilotSdkCliNotFoundError,
     isCopilotSdkPackageInstalled,
@@ -470,12 +469,11 @@ const checkCopilotSdkEnvironment = async (
     providerConfig: RawConfig,
     timeout: number
 ): Promise<{ ok: boolean; error?: string; details?: string; modelWarning?: string }> => {
-    // Mirror the service: an unset model is not a failure, it selects the default
-    // (copilot-sdk.service.ts). Reporting "No model configured" here contradicted the
-    // runtime, which activates on a key or COPILOT_GITHUB_TOKEN alone (issue #268).
-    const configuredModel = getConfiguredModels(providerConfig)[0] || '';
-    const model = configuredModel || COPILOT_SDK_DEFAULT_MODEL;
-    const modelLabel = configuredModel ? model : `${model} (default)`;
+    // Callers gate on a configured model before reaching here, so this is never empty.
+    // The service's own `|| COPILOT_SDK_DEFAULT_MODEL` fallback cannot stand in for it:
+    // the fan-out is `from(getModels(ai))` (ai-request.manager.ts), so an empty model
+    // list emits zero requests and the service default is never consulted.
+    const model = getConfiguredModels(providerConfig)[0] || '';
 
     const prereqFailure = checkCopilotSdkPrereqs();
     if (prereqFailure) {
@@ -526,8 +524,8 @@ const checkCopilotSdkEnvironment = async (
     return {
         ok: true,
         details: version
-            ? `CLI: ${version}${authLabel}; Model: ${modelLabel}; Node: ${nodeVersion}`
-            : `Model: ${modelLabel}${authLabel}; Node: ${nodeVersion}`,
+            ? `CLI: ${version}${authLabel}; Model: ${model}; Node: ${nodeVersion}`
+            : `Model: ${model}${authLabel}; Node: ${nodeVersion}`,
         modelWarning,
     };
 };
@@ -659,13 +657,25 @@ const checkProviderHealth = async (provider: BuiltinService, providerConfig: Raw
 
     if (provider === 'COPILOT_SDK') {
         // Opt-in is a model OR a key OR COPILOT_GITHUB_TOKEN — the same signal the
-        // runtime uses (issue #254). Gating on the model alone made doctor report an
-        // env-token-only setup as unconfigured while generation worked (issue #268).
+        // runtime uses (issue #254). Gating the skip on the model alone told a user who
+        // opted in with a key or a token that nothing was configured (issue #268).
         if (!hasCopilotSdkAvailable(providerConfig)) {
             return {
                 provider,
                 status: 'skipped',
                 message: 'Not configured (needs model, key, or COPILOT_GITHUB_TOKEN)',
+            };
+        }
+
+        // Opted in, but the request fan-out is one request per configured model
+        // (ai-request.manager.ts), so an empty model list sends nothing. The provider is
+        // selected and still produces no suggestions — a warning, not healthy.
+        if (getConfiguredModels(providerConfig).length === 0) {
+            return {
+                provider,
+                status: 'warning',
+                message: 'Opted in but no model configured — no requests will be sent',
+                details: 'Set COPILOT_SDK.model (e.g. gpt-4.1)',
             };
         }
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3,9 +3,10 @@ import { execSync } from 'child_process';
 import chalk from 'chalk';
 import { command } from 'cleye';
 
-import { hasBedrockAccess, hasConfiguredModels } from './get-available-ais.js';
+import { getConfiguredModels, hasBedrockAccess, hasConfiguredModels, hasCopilotSdkAvailable } from './get-available-ais.js';
 import {
     ALL_COPILOT_SDK_KNOWN_MODELS,
+    COPILOT_SDK_DEFAULT_MODEL,
     buildCopilotSdkClientOptions,
     isCopilotSdkCliNotFoundError,
     isCopilotSdkPackageInstalled,
@@ -20,7 +21,15 @@ import {
     isValidGitHubModelsModelId,
 } from '../services/ai/github-models.utils.js';
 import { HttpRequestBuilder } from '../services/http/http-request.builder.js';
-import { BUILTIN_SERVICES, BuiltinService, DEFAULT_OLLAMA_HOST, RawConfig, ValidConfig, getConfig } from '../utils/config.js';
+import {
+    BUILTIN_SERVICES,
+    BuiltinService,
+    DEFAULT_OLLAMA_HOST,
+    RawConfig,
+    SUBSCRIPTION_CLI_SERVICES,
+    ValidConfig,
+    getConfig,
+} from '../utils/config.js';
 import { handleCliError } from '../utils/error.js';
 import { findLazygitConfig, hasAicommitIntegration, isLazygitInstalled } from '../utils/lazygit.js';
 
@@ -81,15 +90,6 @@ const STATUS_LABELS: Record<HealthStatus, (text: string) => string> = {
  */
 const hasApiKey = (value: RawConfig): boolean => {
     return typeof value.key === 'string' && value.key.trim().length > 0;
-};
-
-const hasConfiguredModel = (value: RawConfig): boolean => {
-    const models = Array.isArray(value.model)
-        ? (value.model as string[])
-        : typeof value.model === 'string' && value.model.trim().length > 0
-          ? [(value.model as string).trim()]
-          : [];
-    return models.length > 0;
 };
 
 const isNonEmptyObject = (value: unknown): value is Record<string, unknown> => {
@@ -267,11 +267,7 @@ const checkOpenRouterConnection = async (
 
         const models = response.data?.data ?? [];
 
-        const configuredModels = hasConfiguredModel(providerConfig)
-            ? Array.isArray(providerConfig.model)
-                ? (providerConfig.model as string[])
-                : [providerConfig.model as string]
-            : [];
+        const configuredModels = getConfiguredModels(providerConfig);
 
         if (configuredModels.length === 0) {
             return {
@@ -442,11 +438,7 @@ const probeCopilotSdkAuth = async (
 
 // Static (non-network) prerequisites for COPILOT_SDK. Returns a failure reason,
 // or null when the environment is ready for the live auth probe.
-const checkCopilotSdkPrereqs = (model: string): { error: string; details?: string } | null => {
-    if (!model) {
-        return { error: 'No model configured' };
-    }
-
+const checkCopilotSdkPrereqs = (): { error: string; details?: string } | null => {
     const copilotEnvToken = (process.env.COPILOT_GITHUB_TOKEN || '').trim();
     if (copilotEnvToken.startsWith('ghp_')) {
         return {
@@ -478,11 +470,14 @@ const checkCopilotSdkEnvironment = async (
     providerConfig: RawConfig,
     timeout: number
 ): Promise<{ ok: boolean; error?: string; details?: string; modelWarning?: string }> => {
-    const model = Array.isArray(providerConfig.model)
-        ? String(providerConfig.model[0] || '').trim()
-        : String(providerConfig.model || '').trim();
+    // Mirror the service: an unset model is not a failure, it selects the default
+    // (copilot-sdk.service.ts). Reporting "No model configured" here contradicted the
+    // runtime, which activates on a key or COPILOT_GITHUB_TOKEN alone (issue #268).
+    const configuredModel = getConfiguredModels(providerConfig)[0] || '';
+    const model = configuredModel || COPILOT_SDK_DEFAULT_MODEL;
+    const modelLabel = configuredModel ? model : `${model} (default)`;
 
-    const prereqFailure = checkCopilotSdkPrereqs(model);
+    const prereqFailure = checkCopilotSdkPrereqs();
     if (prereqFailure) {
         return { ok: false, ...prereqFailure };
     }
@@ -531,8 +526,8 @@ const checkCopilotSdkEnvironment = async (
     return {
         ok: true,
         details: version
-            ? `CLI: ${version}${authLabel}; Model: ${model}; Node: ${nodeVersion}`
-            : `Model: ${model}${authLabel}; Node: ${nodeVersion}`,
+            ? `CLI: ${version}${authLabel}; Model: ${modelLabel}; Node: ${nodeVersion}`
+            : `Model: ${modelLabel}${authLabel}; Node: ${nodeVersion}`,
         modelWarning,
     };
 };
@@ -663,11 +658,14 @@ const checkProviderHealth = async (provider: BuiltinService, providerConfig: Raw
     }
 
     if (provider === 'COPILOT_SDK') {
-        if (!hasConfiguredModel(providerConfig)) {
+        // Opt-in is a model OR a key OR COPILOT_GITHUB_TOKEN — the same signal the
+        // runtime uses (issue #254). Gating on the model alone made doctor report an
+        // env-token-only setup as unconfigured while generation worked (issue #268).
+        if (!hasCopilotSdkAvailable(providerConfig)) {
             return {
                 provider,
                 status: 'skipped',
-                message: 'No models configured',
+                message: 'Not configured (needs model, key, or COPILOT_GITHUB_TOKEN)',
             };
         }
 
@@ -696,6 +694,33 @@ const checkProviderHealth = async (provider: BuiltinService, providerConfig: Raw
             status: 'healthy',
             message: 'SDK environment ready',
             details: result.details,
+        };
+    }
+
+    // Subscription-CLI providers authenticate through their own CLI and never carry a
+    // key, so a configured model is the opt-in signal (issue #254, mirrors the runtime
+    // gate in get-available-ais.ts). Without this branch they fall through to the API
+    // key check below and always report "Not configured", even while generation works
+    // (issue #268). COPILOT_SDK is a member of the set too but returns from its own branch
+    // above, so it never reaches here — the COPILOT_GITHUB_TOKEN test in tests/specs/doctor.ts
+    // pins that ordering, since reaching this gate would report it as having no models.
+    // Any future member lands on this model gate by default.
+    if (SUBSCRIPTION_CLI_SERVICES.includes(provider)) {
+        const models = getConfiguredModels(providerConfig);
+
+        if (models.length === 0) {
+            return {
+                provider,
+                status: 'skipped',
+                message: 'No models configured',
+            };
+        }
+
+        return {
+            provider,
+            status: 'healthy',
+            message: 'Model configured',
+            details: `Model: ${models.join(', ')}`,
         };
     }
 

--- a/src/commands/get-available-ais.ts
+++ b/src/commands/get-available-ais.ts
@@ -17,14 +17,14 @@ const hasCopilotSdkAvailable = (value: RawConfig): boolean => {
     return hasConfiguredModels(value) || isNonEmptyString(value.key as string) || isNonEmptyString(process.env.COPILOT_GITHUB_TOKEN);
 };
 
-const hasConfiguredModels = (value: RawConfig): boolean => {
-    const models = Array.isArray(value.model)
-        ? (value.model as string[])
-        : isNonEmptyString(value.model)
-          ? [(value.model as string).trim()]
-          : [];
-    return models.length > 0;
+const getConfiguredModels = (value: RawConfig): string[] => {
+    if (Array.isArray(value.model)) {
+        return value.model as string[];
+    }
+    return isNonEmptyString(value.model) ? [(value.model as string).trim()] : [];
 };
+
+const hasConfiguredModels = (value: RawConfig): boolean => getConfiguredModels(value).length > 0;
 
 const hasBedrockAccess = (value: RawConfig): boolean => {
     const hasApiKey = isNonEmptyString(value.key as string);
@@ -114,4 +114,4 @@ export const getAvailableAIs = (config: ValidConfig, requestType: RequestType): 
         .map(([key]) => key);
 };
 
-export { hasBedrockAccess, hasConfiguredModels };
+export { getConfiguredModels, hasBedrockAccess, hasConfiguredModels, hasCopilotSdkAvailable };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -57,6 +57,17 @@ export const BUILTIN_SERVICES = [
 ] as const;
 export type BuiltinService = (typeof BUILTIN_SERVICES)[number];
 
+// Providers that authenticate through their own subscription CLI rather than an API key.
+// Membership means "no key to check", not "a configured model is the only opt-in signal":
+// COPILOT_SDK also activates on a key or COPILOT_GITHUB_TOKEN (issue #254).
+//
+// Consumed by doctor's health check, where it exists so a future member inherits the model
+// gate instead of the API-key check that misreported CLAUDE_CODE and GEMINI_CLI (issue
+// #268). It is deliberately NOT the runtime gate's grouping in get-available-ais.ts — that
+// one groups OLLAMA with CLAUDE_CODE/GEMINI_CLI and gives COPILOT_SDK its own wider
+// predicate, so swapping this set in there would reintroduce #268 from the other side.
+export const SUBSCRIPTION_CLI_SERVICES: readonly BuiltinService[] = ['COPILOT_SDK', 'CLAUDE_CODE', 'GEMINI_CLI'];
+
 const getXdgBaseDirectory = (type: 'config' | 'data' | 'cache' | 'state'): string => {
     const platform = os.platform();
     const homeDir = os.homedir();

--- a/tests/specs/doctor.ts
+++ b/tests/specs/doctor.ts
@@ -3,6 +3,10 @@ import { expect, testSuite } from 'manten';
 import { summarizeOpenRouterCapabilities } from '../../src/commands/doctor.js';
 import { createFixture } from '../utils.js';
 
+// doctor prints one line per provider; assertions target that line so a message
+// belonging to another provider cannot satisfy them.
+const providerLine = (stdout: string, provider: string): string => stdout.split('\n').find(line => line.includes(provider)) || '';
+
 export default testSuite(({ describe }) => {
     describe('doctor command', async ({ test }) => {
         test('doctor shows health check output', async () => {
@@ -41,6 +45,59 @@ export default testSuite(({ describe }) => {
             expect(stdout).toMatch('GITHUB_MODELS');
             expect(stdout).toMatch('Invalid model ID format');
             expect(stdout).toMatch('publisher/model');
+            await fixture.rm();
+        });
+
+        // Subscription-CLI providers have no API key, so doctor must gate them on a
+        // configured model like the runtime does. Regression guard for issue #268,
+        // where both fell through to the API key check and reported "Not configured"
+        // while generation worked fine.
+        test('doctor reports subscription-CLI providers as healthy when a model is configured', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            await aicommit2(['config', 'set', 'CLAUDE_CODE.model=sonnet']);
+            await aicommit2(['config', 'set', 'GEMINI_CLI.model=gemini-2.5-pro']);
+
+            const { stdout } = await aicommit2(['doctor']);
+
+            expect(providerLine(stdout, 'CLAUDE_CODE')).toMatch('Model configured');
+            expect(providerLine(stdout, 'CLAUDE_CODE')).toMatch('Model: sonnet');
+            expect(providerLine(stdout, 'CLAUDE_CODE')).not.toMatch('Not configured');
+
+            expect(providerLine(stdout, 'GEMINI_CLI')).toMatch('Model configured');
+            expect(providerLine(stdout, 'GEMINI_CLI')).not.toMatch('Not configured');
+            await fixture.rm();
+        });
+
+        test('doctor reports subscription-CLI providers as missing models, not missing keys', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const { stdout } = await aicommit2(['doctor']);
+
+            expect(providerLine(stdout, 'CLAUDE_CODE')).toMatch('No models configured');
+            expect(providerLine(stdout, 'GEMINI_CLI')).toMatch('No models configured');
+            await fixture.rm();
+        });
+
+        // COPILOT_SDK opts in on a model OR a key OR COPILOT_GITHUB_TOKEN, so gating
+        // doctor on the model alone reported an env-token-only setup as unconfigured
+        // while generation worked — the same divergence as issue #268.
+        test('doctor opts COPILOT_SDK in on COPILOT_GITHUB_TOKEN alone, with no model configured', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const { stdout } = await aicommit2(['doctor'], { env: { COPILOT_GITHUB_TOKEN: 'ghp_classicTokenForTest' } });
+
+            // The classic-PAT rejection sits behind the opt-in gate and needs no network,
+            // so reaching it proves the gate passed without a configured model.
+            expect(providerLine(stdout, 'COPILOT_SDK')).toMatch('Unsupported classic PAT');
+            expect(providerLine(stdout, 'COPILOT_SDK')).not.toMatch('Not configured');
+            await fixture.rm();
+        });
+
+        // The skip message names all three opt-in signals: after the gate widened, telling
+        // the user to configure a model would hide the key and token paths.
+        test('doctor still skips COPILOT_SDK when no opt-in signal is present', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const { stdout } = await aicommit2(['doctor']);
+
+            expect(providerLine(stdout, 'COPILOT_SDK')).toMatch('Not configured (needs model, key, or COPILOT_GITHUB_TOKEN)');
             await fixture.rm();
         });
 

--- a/tests/specs/doctor.ts
+++ b/tests/specs/doctor.ts
@@ -80,14 +80,28 @@ export default testSuite(({ describe }) => {
         // COPILOT_SDK opts in on a model OR a key OR COPILOT_GITHUB_TOKEN, so gating
         // doctor on the model alone reported an env-token-only setup as unconfigured
         // while generation worked — the same divergence as issue #268.
-        test('doctor opts COPILOT_SDK in on COPILOT_GITHUB_TOKEN alone, with no model configured', async () => {
+        test('doctor runs the COPILOT_SDK environment check once the provider is opted in', async () => {
             const { fixture, aicommit2 } = await createFixture();
+            await aicommit2(['config', 'set', 'COPILOT_SDK.model=gpt-4.1']);
             const { stdout } = await aicommit2(['doctor'], { env: { COPILOT_GITHUB_TOKEN: 'ghp_classicTokenForTest' } });
 
-            // The classic-PAT rejection sits behind the opt-in gate and needs no network,
-            // so reaching it proves the gate passed without a configured model.
+            // The classic-PAT rejection sits behind both gates and needs no network. Reaching
+            // it also pins branch order: the shared subscription-CLI gate runs after this one,
+            // and would have reported the configured model as healthy instead.
             expect(providerLine(stdout, 'COPILOT_SDK')).toMatch('Unsupported classic PAT');
-            expect(providerLine(stdout, 'COPILOT_SDK')).not.toMatch('Not configured');
+            expect(providerLine(stdout, 'COPILOT_SDK')).not.toMatch('Model configured');
+            await fixture.rm();
+        });
+
+        // The fan-out is one request per configured model, so opting in without a model
+        // selects the provider and then sends nothing. Reporting that as healthy would be
+        // the #268 false report pointed the other way.
+        test('doctor warns when COPILOT_SDK is opted in by token but has no model', async () => {
+            const { fixture, aicommit2 } = await createFixture();
+            const { stdout } = await aicommit2(['doctor'], { env: { COPILOT_GITHUB_TOKEN: 'github_pat_tokenForTest' } });
+
+            expect(providerLine(stdout, 'COPILOT_SDK')).toMatch('no model configured');
+            expect(providerLine(stdout, 'COPILOT_SDK')).not.toMatch('Not configured (needs');
             await fixture.rm();
         });
 


### PR DESCRIPTION
## Summary

`aicommit2 doctor` reported `CLAUDE_CODE` as **Not configured** even when it was set up and generating commit messages (#268). The same divergence existed for `GEMINI_CLI`, which the reporter left untested, and in mirrored form for `COPILOT_SDK`.

`checkProviderHealth` had no branch for the first two, so they fell through to the generic API key check. Subscription-CLI providers authenticate through their own CLI and never carry a key, so that check could never pass — they were unreachable-healthy regardless of config. Generation worked because `get-available-ais.ts` gates them on a configured model instead.

`COPILOT_SDK` had a related divergence in its skip message: doctor demanded a configured model, while the runtime activates on a model **or** a key **or** `COPILOT_GITHUB_TOKEN`. A user who opted in with a key or token was told nothing was configured.

That setup does not actually generate, though — the fan-out is one request per configured model (`from(getModels(ai))`), so an empty model list emits zero requests and the service's own default-model fallback is never consulted (`countRequests` returns 0). Doctor therefore reports it as a **warning** naming the fix, rather than healthy. Making the runtime actually default is a generation change and is deliberately not in this PR.

The root cause is that doctor re-derived provider availability rather than reading the runtime's predicate. This PR closes both symptoms and removes one of the two duplicate encodings.

## Changes

**`src/commands/doctor.ts`**
- New branch for the subscription-CLI set: no model → `No models configured`, model → `Model configured (Model: …)`.
- `COPILOT_SDK`'s skip now gates on the runtime's `hasCopilotSdkAvailable` instead of the model alone, and names all three opt-in signals, since telling the user to configure a model hid the key and token paths.
- Opted in with no model → warning `Opted in but no model configured — no requests will be sent`, because that is what the fan-out does. This also short-circuits before the live auth probe, which previously ran only to describe a provider that would send nothing. `checkCopilotSdkPrereqs`'s `if (!model)` guard became unreachable behind the new gate, so the guard and its now-unused parameter were removed.
- Local `hasConfiguredModel` dropped in favour of the shared helper.

**`src/commands/get-available-ais.ts`** — `getConfiguredModels` extracted, `hasConfiguredModels` defined on top of it, both exported. Doctor consumes them, so the model-parsing logic exists once.

**`src/utils/config.ts`** — `SUBSCRIPTION_CLI_SERVICES` gives the set a single home, so a future member inherits the model gate rather than the API key check that caused this bug.

**`tests/specs/doctor.ts`** — four regression tests plus a `providerLine` helper, so an assertion cannot be satisfied by another provider's line.

**`docs/providers/copilot-sdk.md`** — the documented healthy signal now matches the default-model behaviour.

## How to Test

```bash
pnpm build
SCRATCH=$(mktemp -d); mkdir -p "$SCRATCH/aicommit2"
printf '[CLAUDE_CODE]\nmodel=sonnet\n' > "$SCRATCH/aicommit2/config.ini"
XDG_CONFIG_HOME="$SCRATCH" node ./dist/cli.mjs doctor
```

Before: `⏭️ CLAUDE_CODE    Not configured`
After: `✅ CLAUDE_CODE    Model configured (Model: sonnet)`

Three states covered by the suite:

| Config | doctor line |
|---|---|
| nothing | `⏭️ COPILOT_SDK  Not configured (needs model, key, or COPILOT_GITHUB_TOKEN)` |
| `COPILOT_GITHUB_TOKEN` only | `⚠️ COPILOT_SDK  Opted in but no model configured — no requests will be sent` |
| token + `COPILOT_SDK.model` | `⚠️ COPILOT_SDK  Unsupported classic PAT …` (reaches the environment check) |
| `CLAUDE_CODE.model=sonnet` | `✅ CLAUDE_CODE  Model configured (Model: sonnet)` |

`pnpm test` → 413 passed, 0 failed (408 on main). Every new test was confirmed to fail before the fix by stashing the source changes and rebuilding.

## Risks

- A key-only `COPILOT_SDK` setup **with** a configured model now reaches `checkCopilotSdkEnvironment`, which it previously exited before. That path runs `copilot --version` and a live auth probe, so those users see doctor take longer. Intended — reporting whether the setup actually works is what `doctor` is for, and token-configured setups already paid this cost. Bounded by `config.timeout`.
- The model-less warning describes the fan-out, not the credentials: such a setup may well have valid auth. The message says what is wrong (no requests will be sent) rather than implying the token is bad.
- `CLAUDE_CODE` / `GEMINI_CLI` report healthy from config alone, without probing the `claude` / `gemini` binary. A deliberate choice: `execSync` inherits a non-login shell `PATH`, so probing would produce false "CLI not found" for users whose binary comes from a shell rc — the same class of false negative this PR removes. It matches the existing idiom (`API key configured`, `Cookie configured`) and the documented contract that the CLI is checked at request time.
- `SUBSCRIPTION_CLI_SERVICES` contains `COPILOT_SDK`, which returns from its own branch earlier, so the shared gate never sees it. The `COPILOT_GITHUB_TOKEN` test pins that ordering: reaching the shared gate would report it as having no models.

## Alternatives considered

- **Probing the CLI binary for `CLAUDE_CODE` / `GEMINI_CLI`.** Rejected for the `PATH` reason above. A real binary-and-auth probe is worth doing, but as its own change with its own handling of non-login shells.
- **Reusing `SUBSCRIPTION_CLI_SERVICES` for the runtime gate in `get-available-ais.ts`.** Rejected: the runtime groups `OLLAMA` with `CLAUDE_CODE`/`GEMINI_CLI` and gives `COPILOT_SDK` a wider predicate, so substituting the set there would reintroduce this bug from the other side. The constant's comment says so, to stop a future reader from making that edit.
- **Leaving `COPILOT_SDK` alone.** It was raised as out of scope first, since its gate came out of #256/#259. Fixing it here was a deliberate call: it is the same defect class, and leaving one half in place would have left the next reader with a working example of the pattern.
- **Making the runtime default the model when `COPILOT_SDK` is opted in by key or token** (so `subscriptionCliConfigParsers.model` yields `[gpt-4.1]`). That is arguably what #254 intended, and it would make the model-less setup actually generate. Rejected here because it changes generation behaviour, not a health report, and deserves its own change and its own review.

## Checklist

- [x] `pnpm test` passes (413 passed, 0 failed)
- [x] `pnpm lint` passes, zero warnings
- [x] `pnpm build` passes
- [x] `pnpm type-check` unchanged — 67 pre-existing errors, none in the touched files
- [x] Regression tests fail without the fix (verified by stashing)
- [x] Docs checked for drift (`docs/`, `README.md`)
- [x] Under the 300-line review budget (132 insertions, 39 deletions)

Closes #268
